### PR TITLE
Feature/us9 update task status

### DIFF
--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/task/dto/TaskStatusUpdateRequest.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/task/dto/TaskStatusUpdateRequest.java
@@ -1,0 +1,28 @@
+// file: task-tracker-backend/src/main/java/com/example/tasktracker/backend/task/dto/TaskStatusUpdateRequest.java
+package com.example.tasktracker.backend.task.dto;
+
+import com.example.tasktracker.backend.task.entity.TaskStatus;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * DTO (Data Transfer Object) для запроса на обновление статуса задачи.
+ * Используется в операции PATCH для частичного обновления задачи,
+ * затрагивая только ее статус.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TaskStatusUpdateRequest {
+
+    /**
+     * Новый статус для задачи. Обязательное поле.
+     * Сообщение об ошибке валидации извлекается из Resource Bundle.
+     */
+    @NotNull(message = "{task.validation.status.notNull}")
+    private TaskStatus status;
+}


### PR DESCRIPTION
## Описание (Description)

Этот Pull Request реализует User Story **US9: "Пометка задачи как сделанной/несделанной"**.
Добавлен новый эндпоинт `PATCH /api/v1/tasks/{taskId}`, который позволяет аутентифицированному пользователю частично обновить свою задачу, а именно – изменить ее статус (например, с `PENDING` на `COMPLETED` или наоборот).

## Реализованный функционал (Implemented Functionality)

*   **API Эндпоинт:**
    *   Реализован `PATCH /api/v1/tasks/{taskId}` для обновления статуса задачи.
*   **Аутентификация и Авторизация:**
    *   Эндпоинт защищен, требует валидный JWT.
    *   Обновление статуса разрешено только владельцу задачи.
*   **DTO для Запроса (`TaskStatusUpdateRequest.java`):**
    *   Создан в пакете `com.example.tasktracker.backend.task.dto`.
    *   Содержит одно поле `status` (enum `TaskStatus`).
    *   Использует аннотацию `@NotNull` для валидации поля `status` с сообщением из Resource Bundle (`{task.validation.status.notNull}`).
    *   Покрыт Javadoc.
*   **Сервисный Слой (`TaskService.java`):**
    *   Добавлен метод `updateTaskStatusForCurrentUserOrThrow(Long taskId, TaskStatusUpdateRequest request, Long currentUserId)`.
    *   Использует существующий `taskRepository.findByIdAndUserId(...)` для поиска задачи и проверки владения.
    *   Применяет существующий приватный метод `updateCompletedAtBasedOnStatus(...)` для корректной установки или сброса поля `completedAt` при изменении статуса.
    *   Временная метка `updatedAt` устанавливается вручную с использованием инжектированного `Clock` и округляется до микросекунд (согласно **ADR-0033**).
    *   Избыточный вызов `taskRepository.save()` отсутствует, так как сущность является управляемой в рамках транзакции.
    *   Javadoc для нового метода и класса (если требовалось) обновлен.
*   **Контроллер (`TaskController.java`):**
    *   Добавлен метод `updateTaskStatus(@PathVariable Long taskId, @Valid @RequestBody TaskStatusUpdateRequest request, @AuthenticationPrincipal AppUserDetails currentUserDetails)`.
    *   Использует `ControllerSecurityUtils.getCurrentUserId()` для получения ID текущего пользователя.
    *   Делегирует обработку в `TaskService`.
    *   Возвращает `ResponseEntity.ok(updatedTaskResponse)` при успехе.
    *   Javadoc для нового метода обновлен.
*   **Обработка ошибок:**
    *   **404 Not Found (`TaskNotFoundException`):** Если задача не существует или не принадлежит текущему пользователю.
    *   **400 Bad Request (`ValidationException` / `HttpMessageConversionException` / `TypeMismatchException`):** При невалидном DTO, некорректном JSON или неверном формате `taskId`.
    *   **401 Unauthorized:** При проблемах с JWT.
    *   Все ошибки обрабатываются через `GlobalExceptionHandler` и возвращаются как `ProblemDetail`.
*   **Локализация:**
    *   Добавлен ключ `task.validation.status.notNull` в `i18n/task/messages.properties`.

## Критерии Приемки (Acceptance Criteria Checklist) для US9

*   [x] **AC1: Защищенный эндпоинт:** `PATCH /api/v1/tasks/{taskId}` требует валидный JWT.
*   [x] **AC2: Валидация запроса (`TaskStatusUpdateRequest.java`):** Проверяется, что `status` не `null`.
*   [x] **AC3: Успешное обновление статуса (200 OK):** Поле `status` обновляется, `updatedAt` обновляется, `completedAt` обрабатывается корректно, возвращается `TaskResponse`.
*   [x] **AC4: Обработка ненайденной/чужой задачи (404 Not Found):** Возвращает 404 с `ProblemDetail`.
*   [x] **AC5: Логирование:** Реализовано.
*   [x] **AC6: Javadoc:** Обновлен.
*   [x] **AC7: Тесты:**
    *   [x] Интеграционные тесты для `PATCH /api/v1/tasks/{taskId}` написаны и проходят (успешное изменение статуса PENDING -> COMPLETED и COMPLETED -> PENDING, проверка `completedAt`, ошибки DTO, 404, 401, невалидный `taskId`). Тесты следуют **ADR-0034**.
    *   [x] Юнит-тесты для `TaskService.updateTaskStatusForCurrentUserOrThrow` написаны и проходят.

## Соответствие Definition of Done (DoD Checklist)

*   [x] Код написан и соответствует стандартам проекта (ADRы, стиль).
*   [x] Javadoc написан/обновлен.
*   [x] Реализованы все AC для US9.
*   [x] Юнит-тесты написаны и проходят.
*   [x] Интеграционные тесты написаны и проходят.
*   [x] Покрытие кода тестами (JaCoCo) проверено.
*   [x] Код успешно прошел Code Review.
*   [x] CI/CD пайплайн (Jenkins) успешно проходит для этого кода.
*   [x] Документация (ADRы) не требовала значительного обновления для этой US, кроме подтверждения соответствия ADR-0030 и ADR-0033. Javadoc обновлен.
*   [x] Новых критических технических задач или техдолга не выявлено.

## Как тестировать (How to Test Manually - опционально)

1.  Запустить приложение и зависимости.
2.  Зарегистрировать/залогинить пользователя (`testUser1`), получить JWT.
3.  Создать задачу через `POST /api/v1/tasks` (статус по умолчанию PENDING). Запомнить `taskId`.
4.  Выполнить `PATCH /api/v1/tasks/{taskId}` с телом `{"status": "COMPLETED"}` и валидным JWT.
    *   Ожидаемый ответ: 200 OK, JSON с `TaskResponse`, где `status` = `COMPLETED`, `completedAt` установлено.
5.  Выполнить `PATCH /api/v1/tasks/{taskId}` с телом `{"status": "PENDING"}`.
    *   Ожидаемый ответ: 200 OK, JSON с `TaskResponse`, где `status` = `PENDING`, `completedAt` = `null`.
6.  Попробовать обновить статус с невалидным DTO (например, `{"status": null}` или пустой JSON).
    *   Ожидаемый ответ: 400 Bad Request, `ProblemDetail`.
7.  Попробовать обновить статус несуществующей задачи.
    *   Ожидаемый ответ: 404 Not Found, `ProblemDetail`.

