### PR TITLE
feat(frontend): Verify token on load via /users/me API call

### DIFF
--- a/task-tracker-frontend/js/api.js
+++ b/task-tracker-frontend/js/api.js
@@ -13,7 +13,7 @@ window.taskTrackerApi = {
      * @param {object} registrationData - Данные для регистрации { email, password, repeatPassword }.
      * @returns {Promise} jQuery Promise.
      */
-    registerUser: function(registrationData) {
+    registerUser: function (registrationData) {
         return $.ajax({
             url: `${this.BASE_URL}/users/register`,
             method: 'POST',
@@ -27,12 +27,27 @@ window.taskTrackerApi = {
      * @param {object} loginData - Данные для входа { email, password }.
      * @returns {Promise} jQuery Promise.
      */
-    loginUser: function(loginData) {
+    loginUser: function (loginData) {
         return $.ajax({
             url: `${this.BASE_URL}/auth/login`,
             method: 'POST',
             contentType: 'application/json',
             data: JSON.stringify(loginData)
+        });
+    },
+    /**
+     * Запрашивает данные текущего аутентифицированного пользователя.
+     * Требует наличия валидного JWT в заголовках.
+     * @param {string} token - JWT токен.
+     * @returns {Promise} jQuery Promise.
+     */
+    getCurrentUser: function (token) {
+        return $.ajax({
+            url: `${this.BASE_URL}/users/me`,
+            method: 'GET',
+            headers: {
+                'Authorization': 'Bearer ' + token
+            }
         });
     }
 };

--- a/task-tracker-frontend/js/ui.js
+++ b/task-tracker-frontend/js/ui.js
@@ -52,21 +52,17 @@ window.ui = {
      * Проверяет начальное состояние аутентификации при загрузке страницы.
      */
     checkInitialAuthState: function() {
-        //TODO call /users/me to get user info
         const token = localStorage.getItem('jwt_token');
         if (token) {
-            try {
-                const payload = JSON.parse(atob(token.split('.')[1]));
-                if (payload.email) {
-                    this.showLoggedInState(payload.email);
-                } else {
+            window.taskTrackerApi.getCurrentUser(token)
+                .done((user) => {
+                    this.showLoggedInState(user.email);
+                })
+                .fail(() => {
+                    console.error("Token from localStorage is invalid or expired. Clearing token.");
                     localStorage.removeItem('jwt_token');
                     this.showLoggedOutState();
-                }
-            } catch (e) {
-                localStorage.removeItem('jwt_token');
-                this.showLoggedOutState();
-            }
+                });
         } else {
             this.showLoggedOutState();
         }


### PR DESCRIPTION
Этот Pull Request завершает реализацию задачи **FRONT-USER-ME-01** (Отображение email текущего пользователя) и улучшает надежность системы аутентификации на фронтенде. Теперь фронтенд проверяет валидность JWT на сервере при каждой загрузке страницы.

Ранее, после успешной аутентификации или регистрации (задача FRONT-AUTH-01), токен сохранялся в `localStorage`, и UI переключался в "залогиненное" состояние. Однако, если токен становился невалидным или истекал (например, из-за времени или ручного вмешательства), фронтенд продолжал бы показывать пользователя как залогиненного до первой попытки использования токена в API.

Это изменение устраняет эту проблему, обеспечивая активную проверку состояния аутентификации при загрузке страницы.