### PR TITLE
feat(api): Implement PATCH with optimistic locking

### DIFF
--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/task/dto/TaskResponse.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/task/dto/TaskResponse.java
@@ -63,6 +63,13 @@ public class TaskResponse {
     Instant completedAt;
 
     /**
+     * Версия сущности для оптимистической блокировки.
+     * Клиент должен передавать это значение при обновлении задачи.
+     */
+    @Schema(description = "Версия сущности для оптимистической блокировки.", example = "0")
+    private Integer version;
+
+    /**
      * Идентификатор пользователя, которому принадлежит задача.
      */
     @Schema(description = "Идентификатор пользователя, которому принадлежит задача.", example = "1")
@@ -104,6 +111,7 @@ public class TaskResponse {
                 task.getCreatedAt(),
                 task.getUpdatedAt(),
                 task.getCompletedAt(),
+                task.getVersion(),
                 task.getUser().getId()
         );
     }

--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/task/dto/TaskUpdateRequest.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/task/dto/TaskUpdateRequest.java
@@ -43,4 +43,11 @@ public class TaskUpdateRequest {
     @Schema(description = "Новый статус задачи.", example = "PENDING")
     @NotNull(message = "{task.validation.status.notNull}")
     private TaskStatus status;
+
+    /**
+     * The current version of the task entity, required for optimistic locking.
+     */
+    @Schema(description = "Текущая версия задачи для оптимистической блокировки.", example = "0", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotNull(message = "{task.validation.version.notNull}")
+    private Integer version;
 }

--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/task/entity/Task.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/task/entity/Task.java
@@ -80,6 +80,14 @@ public class Task {
     private Instant completedAt;
 
     /**
+     * Поле для оптимистической блокировки.
+     * Автоматически инкрементируется Hibernate при каждом обновлении сущности.
+     */
+    @Version
+    @Column(name = "version", nullable = false)
+    private Integer version;
+
+    /**
      * Пользователь, которому принадлежит эта задача.
      * Связь {@link ManyToOne}. Владелец не может быть изменен после создания.
      */

--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/task/service/TaskService.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/task/service/TaskService.java
@@ -208,7 +208,6 @@ public class TaskService {
         // Обновляем поля
         taskToUpdate.setTitle(request.getTitle());
         taskToUpdate.setDescription(request.getDescription());
-        taskToUpdate.setVersion(request.getVersion());
 
         Instant now = Instant.now(clock).truncatedTo(ChronoUnit.MICROS);
 
@@ -275,6 +274,8 @@ public class TaskService {
 
             Set<ConstraintViolation<TaskUpdateRequest>> violations = validator.validate(updateRequestDto);
             if (!violations.isEmpty()) {
+                log.warn("Invalid task update request for task ID: {} for user ID: {}. Violations: {}",
+                        taskId, currentUserId, violations);
                 throw new ConstraintViolationException(violations);
             }
 

--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/web/exception/ResourceConflictException.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/web/exception/ResourceConflictException.java
@@ -1,0 +1,46 @@
+package com.example.tasktracker.backend.web.exception;
+
+import com.example.tasktracker.backend.web.ApiConstants;
+import lombok.Getter;
+import lombok.NonNull;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.ErrorResponseException;
+
+import java.net.URI;
+
+/**
+ * Исключение, выбрасываемое при конфликте версий ресурса (оптимистическая блокировка).
+ * Устанавливает HTTP-статус 409 Conflict и предоставляет информацию о конфликтующем ресурсе.
+ */
+@Getter
+public class ResourceConflictException extends ErrorResponseException {
+
+    private static final HttpStatus STATUS = HttpStatus.CONFLICT;
+    public static final String PROBLEM_TYPE_SUFFIX = "resource.conflict";
+    public static final String PROBLEM_TYPE_URI_PATH = "resource-conflict";
+    public static final String CONFLICTING_RESOURCE_ID_PROPERTY = "conflictingResourceId";
+
+    private final Long conflictingResourceId;
+
+    public ResourceConflictException(@NonNull Long conflictingResourceId) {
+        super(STATUS);
+        this.conflictingResourceId = conflictingResourceId;
+        getBody().setType(URI.create(ApiConstants.PROBLEM_TYPE_BASE_URI + PROBLEM_TYPE_URI_PATH));
+        getBody().setProperty(CONFLICTING_RESOURCE_ID_PROPERTY, conflictingResourceId);
+    }
+
+    @Override
+    public String getTitleMessageCode() {
+        return "problemDetail." + PROBLEM_TYPE_SUFFIX + ".title";
+    }
+
+    @Override
+    public String getDetailMessageCode() {
+        return "problemDetail." + PROBLEM_TYPE_SUFFIX + ".detail";
+    }
+
+    @Override
+    public String getTypeMessageCode() {
+        return null; // Type URI устанавливается напрямую
+    }
+}

--- a/task-tracker-backend/src/main/resources/db/changelog/changesets/2025-06-17-09-00-add-version-to-tasks-table.yaml
+++ b/task-tracker-backend/src/main/resources/db/changelog/changesets/2025-06-17-09-00-add-version-to-tasks-table.yaml
@@ -1,0 +1,28 @@
+databaseChangeLog:
+  - changeSet:
+      id: 5 # Следующий по порядку ID
+      author: dailar401@gmail.com
+      comment: "Add nullable version column to tasks table"
+      changes:
+        - addColumn:
+            tableName: tasks
+            columns:
+              - column:
+                  name: version
+                  type: INT
+                  constraints:
+                    nullable: true # Временно разрешаем NULL
+
+  - changeSet:
+      id: 6
+      author: dailar401@gmail.com
+      comment: "Initialize version for existing tasks and make it non-nullable"
+      changes:
+        - sql:
+            comment: "Set initial version to 0 for all existing tasks"
+            dbms: postgresql
+            sql: UPDATE tasks SET version = 0 WHERE version IS NULL;
+        - addNotNullConstraint:
+            tableName: tasks
+            columnName: version
+            columnDataType: INT

--- a/task-tracker-backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/task-tracker-backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -7,3 +7,5 @@ databaseChangeLog:
       file: db/changelog/changesets/2025-05-27-14-55-add-index-tasks-user-created-at.yaml
   - include:
       file: db/changelog/changesets/2025-05-31-create-undelivered-email-commands-table.yaml
+  - include:
+      file: db/changelog/changesets/2025-06-17-09-00-add-version-to-tasks-table.yaml

--- a/task-tracker-backend/src/main/resources/i18n/common/messages.properties
+++ b/task-tracker-backend/src/main/resources/i18n/common/messages.properties
@@ -25,3 +25,7 @@ problemDetail.validation.methodArgumentNotValid.detail=Validation failed. Found 
 # --- Ключи для TypeMismatchException (400 Bad Request - ошибки конвертации path/query параметров) ---
 problemDetail.request.parameter.typeMismatch.title=Invalid Parameter Format
 problemDetail.request.parameter.typeMismatch.detail=Parameter {0} could not be converted to the required type {2} from the provided value {1}.
+
+# --- Ключи для ResourceConflictException (409 Conflict) ---
+problemDetail.resource.conflict.title=Resource Conflict
+problemDetail.resource.conflict.detail=The resource was modified by another request. Please fetch the latest version and try again.

--- a/task-tracker-backend/src/main/resources/i18n/task/messages.properties
+++ b/task-tracker-backend/src/main/resources/i18n/task/messages.properties
@@ -10,12 +10,13 @@ task.entity.description.size=Task description must not exceed {max} characters.
 task.entity.status.notNull=Task status must not be null.
 task.entity.user.notNull=A task must be assigned to a user.
 
-# --- Validation Messages for TaskCreateRequest DTO ---
+# --- Validation Messages for Task DTOs ---
 task.validation.title.notBlank=Task title is required and cannot be blank.
 task.validation.title.size=Task title cannot exceed {max} characters.
 task.validation.description.size=Task description cannot exceed {max} characters.
 task.validation.status.notNull=Task status must be provided and cannot be null.
+task.validation.version.notNull=Task version must be provided for update operations.
 
 # --- Problem Details: Task Business Errors (TaskNotFoundException) ---
 problemDetail.task.notFound.title=Task Not Found
-problemDetail.task.notFound.detail=Task with ID {0} could not be found or you do not have permission to access it.
+problemDetail.task.notFound.detail=Task with ID {0} could not be found, or you do not have permission to access it.

--- a/task-tracker-backend/src/main/resources/openapi-components.yml
+++ b/task-tracker-backend/src/main/resources/openapi-components.yml
@@ -1,5 +1,32 @@
 components:
   schemas:
+
+    TaskPatchRequest:
+      type: object
+      description: "Тело запроса для частичного обновления задачи (JSON Merge Patch). Отправляйте только те поля, которые нужно изменить, и обязательное поле 'version'."
+      properties:
+        title:
+          type: string
+          description: "Новый заголовок задачи."
+          example: "Очень важный новый заголовок"
+        description:
+          type: string
+          description: "Новое описание задачи. Укажите null, чтобы очистить поле."
+          example: "Детальное описание задачи..."
+          nullable: true
+        status:
+          type: string
+          description: "Новый статус задачи."
+          enum: [ PENDING, COMPLETED ]
+          example: "COMPLETED"
+        version:
+          type: integer
+          format: int32
+          description: "Текущая версия задачи для оптимистической блокировки. Обязательное поле."
+          example: 1
+      required:
+        - version
+
     # ---------------------------------------------------------
     # Общая Базовая Схема для ProblemDetail (RFC 7807)
     # ---------------------------------------------------------
@@ -88,6 +115,17 @@ components:
           properties:
             errorRef: { type: string, format: uuid, description: "Уникальный идентификатор ошибки для отслеживания.", example: "a1b2c3d4-e5f6-7890-1234-567890abcdef" }
 
+    ConflictProblem:
+      description: "Тело ответа для ошибки конфликта версий ресурса (HTTP 409)."
+      allOf:
+        - $ref: '#/components/schemas/BaseProblemDetail'
+        - type: object
+          properties:
+            conflictingResourceId:
+              type: integer
+              format: int64
+              description: "ID ресурса, который вызвал конфликт."
+              example: 123
   responses:
     # ---------------------------------------------------------
     # Определения Компонентов Ответов для Ошибок
@@ -277,6 +315,20 @@ components:
             detail: "A user with email 'test@example.com' already exists."
             instance: "/api/v1/users/register"
             conflictingEmail: "test@example.com"
+
+    ConflictGeneral:
+      description: "Операция не может быть выполнена из-за конфликта с текущим состоянием ресурса (например, устаревшая версия при оптимистической блокировке)."
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ConflictProblem'
+          example:
+            type: "https://task-tracker.example.com/probs/resource-conflict"
+            title: "Resource Conflict"
+            status: 409
+            detail: "The resource was modified by another request. Please fetch the latest version and try again."
+            instance: "/api/v1/tasks/123"
+            conflictingResourceId: 123
 
     # ---------------------------------------------------------
     # 500 - INTERNAL SERVER ERROR


### PR DESCRIPTION
### **Описание (Description)**

Этот Pull Request реализует задачу **API-TASK-PATCH-01** по внедрению гибкого частичного обновления задач и защиты от "потерянных обновлений". Главное нововведение — это эндпоинт `PATCH /api/v1/tasks/{taskId}`, использующий стандарт **JSON Merge Patch (RFC 7396)** и механизм **оптимистической блокировки**.

Кроме того, механизм оптимистической блокировки был также интегрирован в существующий эндпоинт `PUT /api/v1/tasks/{taskId}` для обеспечения консистентности.

**Ключевые изменения и улучшения:**

*   **Частичное Обновление:** Реализован эндпоинт `PATCH`, позволяющий клиентам обновлять только измененные поля задачи (`title`, `description`, `status`).
*   **Оптимистическая Блокировка:** В сущность `Task` и связанные DTO добавлено поле `version`. Все операции обновления (`PUT` и `PATCH`) теперь требуют передачи актуальной версии ресурса, предотвращая конфликты при конкурентном доступе.
*   **Обработка Конфликтов (409 Conflict):** При обнаружении несовпадения версий, API теперь возвращает `HTTP 409 Conflict` с информативным `ProblemDetail`.
*   **Надежная Обработка Ошибок:** Улучшена обработка ошибок в `TaskService`, включая `ObjectOptimisticLockingFailureException` и ошибки парсинга `PATCH`-запроса.
*   **Документация:** Создан **ADR-0038**, формализующий принятый подход к `PATCH`-запросам и оптимистической блокировке. OpenAPI документация полностью обновлена.

### **Реализованный функционал (Implemented Functionality)**

*   **Новый API Эндпоинт:** `PATCH /api/v1/tasks/{taskId}`
    *   **Content-Type:** `application/merge-patch+json`
    *   **Тело запроса:** JSON-объект, содержащий только измененные поля и **обязательное поле `version`**.
    *   **Логика:** Применяет изменения к задаче, обрабатывает `completedAt` при смене статуса, выполняет полную валидацию итогового состояния.
*   **Обновленный API Эндпоинт:** `PUT /api/v1/tasks/{taskId}`
    *   **Тело запроса:** `TaskUpdateRequest` теперь **обязательно** включает поле `version`.
*   **Новая Ошибка API:** `409 Conflict`
    *   Возвращается обоими эндпоинтами (`PUT` и `PATCH`) в случае несовпадения версий.
    *   Тело ответа — `ProblemDetail` с `type: .../resource-conflict` и полем `conflictingResourceId`.
*   **Компоненты:**
    *   **`Task.java`:** Добавлено поле `@Version`.
    *   **`TaskResponse.java`, `TaskUpdateRequest.java`:** Добавлено поле `version`.
    *   **`TaskService.java`:** Реализован метод `patchTask` и обновлен `updateTask`. Внедрена архитектура с не-транзакционными обертками для корректной обработки исключений блокировки.
    *   **`TaskController.java`:** Добавлен новый `PATCH` эндпоинт, работающий с `JsonNode`.
    *   **`ResourceConflictException.java`:** Новое доменное исключение для `409 Conflict`.
    *   **`GlobalExceptionHandler.java`:** Добавлен обработчик для `ResourceConflictException`.
    *   **`openapi-components.yml`:** Добавлены схемы и ответы для `PATCH` и `409 Conflict`.

### **Критерии Приемки (Acceptance Criteria Checklist)**

*   [x] **AC1: `PATCH`-эндпоинт реализован:** `PATCH /api/v1/tasks/{taskId}` существует и требует аутентификации.
*   [x] **AC2: Частичное обновление работает:** Отправка JSON с одним полем (например, `title`) и `version` успешно обновляет только это поле.
*   [x] **AC3: Очистка поля через `null`:** Отправка `{"description": null, "version": ...}` успешно устанавливает `description` в `null`.
*   [x] **AC4: Валидация после патча:** `PATCH`-запрос, делающий сущность невалидной (например, `{"title": "", "version": ...}`), возвращает `400 Bad Request`.
*   [x] **AC5: Оптимистическая блокировка для `PATCH`:**
    *   [x] `PATCH` без поля `version` возвращает `400 Bad Request`.
    *   [x] `PATCH` с неверной `version` возвращает `409 Conflict`.
*   [x] **AC6: Оптимистическая блокировка для `PUT`:** `PUT` с неверной `version` возвращает `409 Conflict`.
*   [x] **AC7: Успешный ответ:** Успешные `PUT` и `PATCH` возвращают `200 OK` с **полным `TaskResponse`, содержащим новую версию**.

### **Соответствие Definition of Done (DoD Checklist)**

*   [x] Код написан и соответствует стандартам проекта.
*   [x] Javadoc написан/обновлен.
*   [x] Реализованы все AC для задачи `API-TASK-PATCH-01`.
*   [x] Юнит-тесты (`TaskServiceTest`) написаны/обновлены и проходят.
*   [x] Интеграционные тесты (`TaskControllerIT`) написаны/обновлены и проходят.
*   [x] Покрытие кода тестами (JaCoCo) проверено, новая логика покрыта.
*   [x] Код успешно прошел Code Review.
*   [x] CI/CD пайплайн (Jenkins) успешно проходит для этого кода.
*   [x] Документация (ADR-0038, OpenAPI) создана/обновлена.
*   [x] Новых критических технических задач или техдолга не выявлено.

### **Как тестировать (How to Test Manually)**

1.  Создать задачу (`POST /tasks`), получить ее `taskId` и `version` (должна быть 0).
2.  **Тест PATCH (успех):** Отправить `PATCH /tasks/{taskId}` с телом `{"title": "Новый PATCH заголовок", "version": 0}`. Ожидаемый ответ: `200 OK` с новым заголовком и `version: 1`.
3.  **Тест PUT (успех):** Отправить `PUT /tasks/{taskId}` с полным DTO и `version: 1`. Ожидаемый ответ: `200 OK`, `version: 2`.
4.  **Тест PATCH (конфликт):** Снова отправить `PATCH /tasks/{taskId}` с `version: 1` (устаревшая). Ожидаемый ответ: `409 Conflict`.
5.  **Тест PUT (конфликт):** Снова отправить `PUT /tasks/{taskId}` с `version: 1` (устаревшая). Ожидаемый ответ: `409 Conflict`.
6.  **Тест PATCH (ошибка валидации):** Отправить `PATCH /tasks/{taskId}` с `version: 2` и `{"title": ""}`. Ожидаемый ответ: `400 Bad Request`.
7.  **Тест PATCH (отсутствие версии):** Отправить `PATCH /tasks/{taskId}` с `{"title": "test"}` (без `version`). Ожидаемый ответ: `400 Bad Request`.

### **Дополнительные Замечания**

*   Удален старый `PATCH`-эндпоинт и DTO `TaskStatusUpdateRequest`.
*   Этот PR является блокером для задачи фронтенда `US-FT-UPDATE`.