### PR TITLE
feat(security): Implement isolated M2M auth with service-aware API Keys

### DIFF
--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/common/MdcKeys.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/common/MdcKeys.java
@@ -29,10 +29,10 @@ public final class MdcKeys {
      * Используется для корреляции логов с запросами от конкретного M2M клиента.
      * Значение: {@value}.
      */
-    public static final String SERVICE_ID = "service.id";
+    public static final String SERVICE_ID = "client.service.id";
 
     /**
      * Ключ MDC для хранения уникального идентификатора экземпляра внутреннего сервиса-клиента (например, pod name).
      */
-    public static final String SERVICE_INSTANCE_ID = "service.instance.id";
+    public static final String SERVICE_INSTANCE_ID = "client.service.instance.id";
 }

--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/common/MdcKeys.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/common/MdcKeys.java
@@ -24,5 +24,15 @@ public final class MdcKeys {
      */
     public static final String CORRELATION_ID = "correlation.id";
 
-    // Можно добавить другие общие ключи MDC по мере необходимости
+    /**
+     * Ключ MDC для хранения идентификатора внутреннего сервиса-клиента.
+     * Используется для корреляции логов с запросами от конкретного M2M клиента.
+     * Значение: {@value}.
+     */
+    public static final String SERVICE_ID = "service.id";
+
+    /**
+     * Ключ MDC для хранения уникального идентификатора экземпляра внутреннего сервиса-клиента (например, pod name).
+     */
+    public static final String SERVICE_INSTANCE_ID = "service.instance.id";
 }

--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/common/MdcKeys.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/common/MdcKeys.java
@@ -33,6 +33,7 @@ public final class MdcKeys {
 
     /**
      * Ключ MDC для хранения уникального идентификатора экземпляра внутреннего сервиса-клиента (например, pod name).
+     * Значение: {@value}.
      */
     public static final String SERVICE_INSTANCE_ID = "client.service.instance.id";
 }

--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/kafka/config/KafkaConfig.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/kafka/config/KafkaConfig.java
@@ -1,6 +1,5 @@
 package com.example.tasktracker.backend.kafka.config;
 
-import com.example.tasktracker.backend.config.KafkaTopicVerifier;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.NewTopic;

--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/kafka/config/KafkaTopicVerifier.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/kafka/config/KafkaTopicVerifier.java
@@ -1,6 +1,5 @@
-package com.example.tasktracker.backend.config;
+package com.example.tasktracker.backend.kafka.config;
 
-import com.example.tasktracker.backend.kafka.config.KafkaConfig;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/security/apikey/ApiKeyAuthentication.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/security/apikey/ApiKeyAuthentication.java
@@ -1,0 +1,54 @@
+package com.example.tasktracker.backend.security.apikey;
+
+import lombok.Getter;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.AuthorityUtils;
+
+import java.util.Collection;
+
+/**
+ * Реализация {@link org.springframework.security.core.Authentication} для представления
+ * аутентифицированного внутреннего сервиса по API-ключу.
+ * <p>
+ * Устанавливается в SecurityContext после успешной валидации API-ключа.
+ * </p>
+ */
+@Getter
+public class ApiKeyAuthentication extends AbstractAuthenticationToken {
+
+    /**
+     * Principal для внутреннего сервиса. Может быть строкой, идентифицирующей сервис.
+     */
+    private final String principal;
+
+    /**
+     * Создает аутентифицированный токен.
+     *
+     * @param principal   Идентификатор аутентифицированного сервиса.
+     * @param authorities Полномочия (обычно пустые для M2M аутентификации по ключу).
+     */
+    public ApiKeyAuthentication(String principal, Collection<? extends GrantedAuthority> authorities) {
+        super(authorities);
+        this.principal = principal;
+        setAuthenticated(true);
+    }
+
+    /**
+     * Создает аутентифицированный токен с пустыми полномочиями.
+     *
+     * @param principal Идентификатор аутентифицированного сервиса.
+     * @return Экземпляр ApiKeyAuthentication.
+     */
+    public static ApiKeyAuthentication authenticated(String principal) {
+        return new ApiKeyAuthentication(principal, AuthorityUtils.NO_AUTHORITIES);
+    }
+
+    /**
+     * Учетные данные (сам ключ) не хранятся в объекте Authentication
+     */
+    @Override
+    public Object getCredentials() {
+        return null;
+    }
+}

--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/security/apikey/ApiKeyAuthentication.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/security/apikey/ApiKeyAuthentication.java
@@ -2,10 +2,7 @@ package com.example.tasktracker.backend.security.apikey;
 
 import lombok.Getter;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.AuthorityUtils;
-
-import java.util.Collection;
 
 /**
  * Реализация {@link org.springframework.security.core.Authentication} для представления
@@ -17,31 +14,20 @@ import java.util.Collection;
 @Getter
 public class ApiKeyAuthentication extends AbstractAuthenticationToken {
 
-    /**
-     * Principal для внутреннего сервиса. Может быть строкой, идентифицирующей сервис.
-     */
-    private final String principal;
+    private final String serviceId;
+    private final String instanceId;
 
     /**
-     * Создает аутентифицированный токен.
+     * Конструктор для создания аутентифицированного токена.
      *
-     * @param principal   Идентификатор аутентифицированного сервиса.
-     * @param authorities Полномочия (обычно пустые для M2M аутентификации по ключу).
+     * @param serviceId  Идентификатор типа сервиса (например, "task-tracker-scheduler").
+     * @param instanceId Уникальный идентификатор экземпляра сервиса.
      */
-    public ApiKeyAuthentication(String principal, Collection<? extends GrantedAuthority> authorities) {
-        super(authorities);
-        this.principal = principal;
+    public ApiKeyAuthentication(String serviceId, String instanceId) {
+        super(AuthorityUtils.NO_AUTHORITIES);
+        this.serviceId = serviceId;
+        this.instanceId = instanceId;
         setAuthenticated(true);
-    }
-
-    /**
-     * Создает аутентифицированный токен с пустыми полномочиями.
-     *
-     * @param principal Идентификатор аутентифицированного сервиса.
-     * @return Экземпляр ApiKeyAuthentication.
-     */
-    public static ApiKeyAuthentication authenticated(String principal) {
-        return new ApiKeyAuthentication(principal, AuthorityUtils.NO_AUTHORITIES);
     }
 
     /**
@@ -50,5 +36,10 @@ public class ApiKeyAuthentication extends AbstractAuthenticationToken {
     @Override
     public Object getCredentials() {
         return null;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return serviceId;
     }
 }

--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/security/apikey/ApiKeyProperties.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/security/apikey/ApiKeyProperties.java
@@ -1,0 +1,39 @@
+package com.example.tasktracker.backend.security.apikey;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+import java.util.Set;
+
+/**
+ * Конфигурационные свойства для аутентификации по API-ключам.
+ * <p>
+ * Читаются из {@code application.yml} с префиксом "app.security.api-key".
+ * Валидация свойств происходит при старте приложения.
+ * </p>
+ */
+@Component
+@ConfigurationProperties(prefix = "app.security.api-key")
+@Validated
+@Getter
+@Setter
+public class ApiKeyProperties {
+
+    /**
+     * Набор валидных API-ключей для доступа к внутренним эндпоинтам.
+     * <p>
+     * Ключи должны быть криптографически случайными строками, содержащими
+     * только символы, безопасные для использования в HTTP-заголовках
+     * (например, из набора [A-Za-z0-9_-]).
+     * </p>
+     * <p>
+     * Это свойство является обязательным и не может быть пустым.
+     * </p>
+     */
+    @NotEmpty(message = "{security.apiKey.validKeys.notEmpty}")
+    private Set<String> validKeys;
+}

--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/security/apikey/ApiKeyProperties.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/security/apikey/ApiKeyProperties.java
@@ -7,7 +7,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
 
-import java.util.Set;
+import java.util.Map;
 
 /**
  * Конфигурационные свойства для аутентификации по API-ключам.
@@ -24,16 +24,15 @@ import java.util.Set;
 public class ApiKeyProperties {
 
     /**
-     * Набор валидных API-ключей для доступа к внутренним эндпоинтам.
+     * Карта, сопоставляющая API-ключи с идентификаторами сервисов-клиентов.
      * <p>
-     * Ключи должны быть криптографически случайными строками, содержащими
-     * только символы, безопасные для использования в HTTP-заголовках
-     * (например, из набора [A-Za-z0-9_-]).
+     * Ключ карты - это сам API-ключ.
+     * Значение карты - строковый идентификатор сервиса (например, "task-tracker-scheduler").
      * </p>
      * <p>
      * Это свойство является обязательным и не может быть пустым.
      * </p>
      */
-    @NotEmpty(message = "{security.apiKey.validKeys.notEmpty}")
-    private Set<String> validKeys;
+    @NotEmpty(message = "{security.apiKey.keysToServices.notEmpty}")
+    private Map<String, String> keysToServices;
 }

--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/security/apikey/ApiKeyValidator.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/security/apikey/ApiKeyValidator.java
@@ -1,0 +1,56 @@
+package com.example.tasktracker.backend.security.apikey;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+
+/**
+ * Сервис, ответственный за валидацию предоставленного API-ключа.
+ * <p>
+ * Сравнивает полученный ключ с набором валидных ключей, определенных
+ * в {@link ApiKeyProperties}, используя метод, устойчивый к атакам по времени.
+ * </p>
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ApiKeyValidator {
+
+    private final ApiKeyProperties apiKeyProperties;
+
+    /**
+     * Проверяет, является ли предоставленный API-ключ валидным.
+     * <p>
+     * Сравнение производится с каждым ключом из сконфигурированного набора
+     * с использованием {@link MessageDigest#isEqual(byte[], byte[])}, чтобы
+     * предотвратить "timing attacks".
+     * </p>
+     *
+     * @param providedKey API-ключ, полученный из запроса. Не должен быть null.
+     * @throws NullPointerException если {@code providedKey} равен null.
+     * @return {@code true}, если ключ найден в наборе валидных ключей, иначе {@code false}.
+     */
+    public boolean isValid(@NonNull String providedKey) {
+        if (apiKeyProperties.getValidKeys() == null) {
+            log.error("CRITICAL: Set of valid API keys is null. Check configuration 'app.security.api-key.valid-keys'.");
+            return false;
+        }
+
+        byte[] providedKeyBytes = providedKey.getBytes(StandardCharsets.UTF_8);
+
+        for (String validKey : apiKeyProperties.getValidKeys()) {
+            byte[] validKeyBytes = validKey.getBytes(StandardCharsets.UTF_8);
+            if (MessageDigest.isEqual(providedKeyBytes, validKeyBytes)) {
+                log.trace("Provided API key matched a configured valid key.");
+                return true;
+            }
+        }
+
+        log.warn("Provided API key did not match any of the configured valid keys.");
+        return false;
+    }
+}

--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/security/apikey/ApiKeyValidator.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/security/apikey/ApiKeyValidator.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 
 /**
  * Сервис, ответственный за валидацию предоставленного API-ключа и идентификацию сервиса.
+ * Использует timing-attack-safe метод сравнения для обеспечения безопасности.
  */
 @Service
 @RequiredArgsConstructor
@@ -26,7 +27,7 @@ public class ApiKeyValidator {
      *
      * @param providedKey API-ключ, полученный из запроса. Не должен быть null.
      * @return {@link Optional} с идентификатором сервиса, если ключ валиден.
-     *         В противном случае, возвращает {@link Optional#empty()}.
+     * В противном случае, возвращает {@link Optional#empty()}.
      */
     public Optional<String> getServiceIdIfValid(@NonNull String providedKey) {
         final Map<String, String> keysToServices = apiKeyProperties.getKeysToServices();
@@ -41,7 +42,7 @@ public class ApiKeyValidator {
             byte[] validKeyBytes = entry.getKey().getBytes(StandardCharsets.UTF_8);
             if (MessageDigest.isEqual(providedKeyBytes, validKeyBytes)) {
                 String serviceId = entry.getValue();
-                log.trace("Provided API key matched. Identified service: '{}'", serviceId);
+                log.debug("Provided API key matched. Identified service: '{}'", serviceId);
                 return Optional.of(serviceId);
             }
         }

--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/security/apikey/InvalidApiKeyException.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/security/apikey/InvalidApiKeyException.java
@@ -1,0 +1,13 @@
+package com.example.tasktracker.backend.security.apikey;
+
+import org.springframework.security.core.AuthenticationException;
+
+/**
+ * Исключение, выбрасываемое при ошибке аутентификации по API-ключу.
+ * Используется для разделения логики обработки ошибок M2M и пользовательской аутентификации.
+ */
+public class InvalidApiKeyException extends AuthenticationException {
+    public InvalidApiKeyException(String msg) {
+        super(msg);
+    }
+}

--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/security/filter/ApiKeyAuthenticationFilter.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/security/filter/ApiKeyAuthenticationFilter.java
@@ -3,6 +3,7 @@ package com.example.tasktracker.backend.security.filter;
 import com.example.tasktracker.backend.common.MdcKeys;
 import com.example.tasktracker.backend.security.apikey.ApiKeyAuthentication;
 import com.example.tasktracker.backend.security.apikey.ApiKeyValidator;
+import com.example.tasktracker.backend.security.apikey.InvalidApiKeyException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -11,7 +12,6 @@ import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.AuthenticationEntryPoint;
@@ -67,7 +67,7 @@ public class ApiKeyAuthenticationFilter extends OncePerRequestFilter {
         if (!StringUtils.hasText(providedKey)) {
             log.warn("Missing API Key in header '{}' for request to {}", API_KEY_HEADER_NAME, request.getRequestURI());
             this.authenticationEntryPoint.commence(request, response,
-                    new BadCredentialsException("API Key is missing."));
+                    new InvalidApiKeyException("API Key is missing."));
             return;
         }
 
@@ -95,7 +95,7 @@ public class ApiKeyAuthenticationFilter extends OncePerRequestFilter {
         } else {
             log.warn("Invalid API Key provided for request to {}", request.getRequestURI());
             this.authenticationEntryPoint.commence(request, response,
-                    new BadCredentialsException("Invalid API Key provided."));
+                    new InvalidApiKeyException("Invalid API Key provided."));
         }
     }
 }

--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/security/filter/ApiKeyAuthenticationFilter.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/security/filter/ApiKeyAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package com.example.tasktracker.backend.security.filter;
 
+import com.example.tasktracker.backend.common.MdcKeys;
 import com.example.tasktracker.backend.security.apikey.ApiKeyAuthentication;
 import com.example.tasktracker.backend.security.apikey.ApiKeyValidator;
 import jakarta.servlet.FilterChain;
@@ -8,16 +9,17 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.AuthenticationEntryPoint;
-import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.Optional;
 
 /**
  * Фильтр Spring Security для аутентификации по статическому API-ключу.
@@ -28,11 +30,12 @@ import java.io.IOException;
  * ошибки в {@link AuthenticationEntryPoint}.
  * </p>
  */
-@Component
 @Slf4j
 public class ApiKeyAuthenticationFilter extends OncePerRequestFilter {
 
     public static final String API_KEY_HEADER_NAME = "X-API-Key";
+    public static final String SERVICE_INSTANCE_ID_HEADER_NAME = "X-Service-Instance-Id";
+    public static final String UNKNOWN_INSTANCE_ID = "[unknown-instance]";
 
     private final ApiKeyValidator apiKeyValidator;
 
@@ -53,7 +56,7 @@ public class ApiKeyAuthenticationFilter extends OncePerRequestFilter {
 
         if (SecurityContextHolder.getContext().getAuthentication() != null &&
                 SecurityContextHolder.getContext().getAuthentication().isAuthenticated()) {
-            log.trace("SecurityContext already contains an authenticated principal for [{}]. Skipping JWT processing.",
+            log.trace("SecurityContext already contains an authenticated principal for [{}].",
                     request.getRequestURI());
             filterChain.doFilter(request, response);
             return;
@@ -68,11 +71,27 @@ public class ApiKeyAuthenticationFilter extends OncePerRequestFilter {
             return;
         }
 
-        if (apiKeyValidator.isValid(providedKey)) {
-            log.trace("Valid API Key found. Setting Authentication in SecurityContext.");
-            Authentication authentication = ApiKeyAuthentication.authenticated("internal-service");
-            SecurityContextHolder.getContext().setAuthentication(authentication);
-            filterChain.doFilter(request, response);
+        Optional<String> serviceIdOptional = apiKeyValidator.getServiceIdIfValid(providedKey);
+
+        if (serviceIdOptional.isPresent()) {
+            String serviceId = serviceIdOptional.get();
+            String instanceId = Optional.ofNullable(request.getHeader(SERVICE_INSTANCE_ID_HEADER_NAME))
+                    .filter(StringUtils::hasText)
+                    .orElseGet(() -> {
+                        log.warn("Missing or blank '{}' header for an authenticated request from service '{}'. " +
+                                "Using default placeholder.", SERVICE_INSTANCE_ID_HEADER_NAME, serviceId);
+                        return UNKNOWN_INSTANCE_ID;
+                    });
+
+            try (
+                    MDC.MDCCloseable ignoredSrv = MDC.putCloseable(MdcKeys.SERVICE_ID, serviceId);
+                    MDC.MDCCloseable ignoredInst = MDC.putCloseable(MdcKeys.SERVICE_INSTANCE_ID, instanceId)
+            ) {
+                log.trace("Valid API Key. Service '{}', Instance '{}' authenticated.", serviceId, instanceId);
+                Authentication authentication = new ApiKeyAuthentication(serviceId, instanceId);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+                filterChain.doFilter(request, response);
+            }
         } else {
             log.warn("Invalid API Key provided for request to {}", request.getRequestURI());
             this.authenticationEntryPoint.commence(request, response,

--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/security/filter/ApiKeyAuthenticationFilter.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/security/filter/ApiKeyAuthenticationFilter.java
@@ -1,0 +1,82 @@
+package com.example.tasktracker.backend.security.filter;
+
+import com.example.tasktracker.backend.security.apikey.ApiKeyAuthentication;
+import com.example.tasktracker.backend.security.apikey.ApiKeyValidator;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * Фильтр Spring Security для аутентификации по статическому API-ключу.
+ * <p>
+ * Извлекает ключ из заголовка "X-API-Key" и валидирует его с помощью
+ * {@link ApiKeyValidator}. В случае успеха, устанавливает в SecurityContext
+ * объект {@link ApiKeyAuthentication}. В случае неудачи, делегирует обработку
+ * ошибки в {@link AuthenticationEntryPoint}.
+ * </p>
+ */
+@Component
+@Slf4j
+public class ApiKeyAuthenticationFilter extends OncePerRequestFilter {
+
+    public static final String API_KEY_HEADER_NAME = "X-API-Key";
+
+    private final ApiKeyValidator apiKeyValidator;
+
+    private final AuthenticationEntryPoint authenticationEntryPoint;
+
+    public ApiKeyAuthenticationFilter(
+            ApiKeyValidator apiKeyValidator,
+            @Qualifier("apiKeyAuthenticationEntryPoint") AuthenticationEntryPoint authenticationEntryPoint) {
+        this.apiKeyValidator = apiKeyValidator;
+        this.authenticationEntryPoint = authenticationEntryPoint;
+    }
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain) throws ServletException, IOException {
+
+        if (SecurityContextHolder.getContext().getAuthentication() != null &&
+                SecurityContextHolder.getContext().getAuthentication().isAuthenticated()) {
+            log.trace("SecurityContext already contains an authenticated principal for [{}]. Skipping JWT processing.",
+                    request.getRequestURI());
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String providedKey = request.getHeader(API_KEY_HEADER_NAME);
+
+        if (!StringUtils.hasText(providedKey)) {
+            log.warn("Missing API Key in header '{}' for request to {}", API_KEY_HEADER_NAME, request.getRequestURI());
+            this.authenticationEntryPoint.commence(request, response,
+                    new BadCredentialsException("API Key is missing."));
+            return;
+        }
+
+        if (apiKeyValidator.isValid(providedKey)) {
+            log.trace("Valid API Key found. Setting Authentication in SecurityContext.");
+            Authentication authentication = ApiKeyAuthentication.authenticated("internal-service");
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            filterChain.doFilter(request, response);
+        } else {
+            log.warn("Invalid API Key provided for request to {}", request.getRequestURI());
+            this.authenticationEntryPoint.commence(request, response,
+                    new BadCredentialsException("Invalid API Key provided."));
+        }
+    }
+}

--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/security/filter/ApiKeyAuthenticationFilter.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/security/filter/ApiKeyAuthenticationFilter.java
@@ -72,9 +72,10 @@ public class ApiKeyAuthenticationFilter extends OncePerRequestFilter {
                     MDC.MDCCloseable ignoredSrv = MDC.putCloseable(MdcKeys.SERVICE_ID, serviceId);
                     MDC.MDCCloseable ignoredInst = MDC.putCloseable(MdcKeys.SERVICE_INSTANCE_ID, instanceId)
             ) {
-                log.trace("Valid API Key. Service '{}', Instance '{}' authenticated.", serviceId, instanceId);
                 Authentication authentication = new ApiKeyAuthentication(serviceId, instanceId);
                 SecurityContextHolder.getContext().setAuthentication(authentication);
+                log.debug("Valid API Key. Service '{}', Instance '{}' authenticated.", serviceId, instanceId);
+
                 filterChain.doFilter(request, response);
             }
         } else {

--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/security/filter/JwtAuthenticationFilter.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/security/filter/JwtAuthenticationFilter.java
@@ -16,6 +16,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -83,7 +84,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     public JwtAuthenticationFilter(
             @NonNull JwtValidator jwtValidator,
             @NonNull JwtAuthenticationConverter jwtAuthenticationConverter,
-            @NonNull AuthenticationEntryPoint authenticationEntryPoint) {
+            @NonNull @Qualifier("bearerTokenProblemDetailsAuthenticationEntryPoint") AuthenticationEntryPoint
+                    authenticationEntryPoint) {
         this.jwtValidator = jwtValidator;
         this.jwtAuthenticationConverter = jwtAuthenticationConverter;
         this.authenticationEntryPoint = authenticationEntryPoint;

--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/security/filter/JwtAuthenticationFilter.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/security/filter/JwtAuthenticationFilter.java
@@ -21,7 +21,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.AuthenticationEntryPoint;
-import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -64,7 +63,6 @@ import java.util.Optional;
  * В случаях, когда {@link AuthenticationEntryPoint} не вызывается (успешная аутентификация по JWT или отсутствие JWT),
  * запрос всегда передается дальше по цепочке фильтров.
  */
-@Component
 @Slf4j
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 

--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/security/handler/ApiKeyProblemDetailsAuthenticationEntryPoint.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/security/handler/ApiKeyProblemDetailsAuthenticationEntryPoint.java
@@ -1,0 +1,39 @@
+package com.example.tasktracker.backend.security.handler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
+/**
+ * Реализация {@link AuthenticationEntryPoint} для обработки ошибок аутентификации
+ * по API-ключу.
+ * <p>
+ * Делегирует обработку исключения {@link AuthenticationException} в
+ * {@link HandlerExceptionResolver}, чтобы {@code @ControllerAdvice} мог сформировать
+ * стандартизированный ответ в формате RFC 9457 Problem Details.
+ * </p>
+ */
+@Component("apiKeyAuthenticationEntryPoint")
+@RequiredArgsConstructor
+@Slf4j
+public class ApiKeyProblemDetailsAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @NonNull
+    private final HandlerExceptionResolver handlerExceptionResolver;
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException) {
+
+        log.debug("ApiKeyProblemDetailsAuthenticationEntryPoint commencing for exception: {}", authException.getMessage());
+        handlerExceptionResolver.resolveException(request, response, null, authException);
+    }
+}

--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/security/handler/BearerTokenProblemDetailsAuthenticationEntryPoint.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/security/handler/BearerTokenProblemDetailsAuthenticationEntryPoint.java
@@ -26,7 +26,7 @@ import java.io.IOException;
  * в {@link HandlerExceptionResolver}, чтобы {@code @ControllerAdvice}
  * мог сформировать ответ в формате RFC 9457 Problem Details.
  */
-@Component
+@Component("bearerTokenProblemDetailsAuthenticationEntryPoint")
 @Slf4j
 @RequiredArgsConstructor
 public class BearerTokenProblemDetailsAuthenticationEntryPoint implements AuthenticationEntryPoint {

--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/security/web/controller/InternalTestController.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/security/web/controller/InternalTestController.java
@@ -1,0 +1,27 @@
+package com.example.tasktracker.backend.security.web.controller;
+
+import com.example.tasktracker.backend.web.ApiConstants;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Временный контроллер для тестирования безопасности внутренних эндпоинтов.
+ * Этот контроллер должен быть удален или отключен в production-профиле.
+ */
+@RestController
+@RequestMapping(ApiConstants.API_V1_PREFIX + "/internal")
+@Profile({"dev","ci"})
+public class InternalTestController {
+
+    /**
+     * Простой эндпоинт, который должен быть доступен только с валидным API-ключом.
+     * @return Ответ 200 OK с простым сообщением.
+     */
+    @GetMapping("/test")
+    public ResponseEntity<String> testInternalEndpoint() {
+        return ResponseEntity.ok("Internal API endpoint reached successfully.");
+    }
+}

--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/security/web/controller/InternalTestController.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/security/web/controller/InternalTestController.java
@@ -2,6 +2,7 @@ package com.example.tasktracker.backend.security.web.controller;
 
 import com.example.tasktracker.backend.security.apikey.ApiKeyAuthentication;
 import com.example.tasktracker.backend.web.ApiConstants;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,6 +16,7 @@ import java.util.Map;
  */
 @RestController
 @RequestMapping(ApiConstants.API_V1_PREFIX + "/internal")
+@Slf4j
 public class InternalTestController {
 
     /**
@@ -30,6 +32,7 @@ public class InternalTestController {
             return ResponseEntity.status(500).body(Map.of("error", "Authentication object not found or not authenticated"));
         }
 
+        log.info("testInternalEndpoint called. ServiceId: {}, InstanceId: {}", apiKeyAuth.getServiceId(), apiKeyAuth.getInstanceId());
         return ResponseEntity.ok(Map.of(
                 "message", "Internal API endpoint reached successfully.",
                 "serviceId", apiKeyAuth.getServiceId(),

--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/security/web/controller/InternalTestController.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/security/web/controller/InternalTestController.java
@@ -1,11 +1,13 @@
 package com.example.tasktracker.backend.security.web.controller;
 
+import com.example.tasktracker.backend.security.apikey.ApiKeyAuthentication;
 import com.example.tasktracker.backend.web.ApiConstants;
-import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
 
 /**
  * Временный контроллер для тестирования безопасности внутренних эндпоинтов.
@@ -13,15 +15,25 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping(ApiConstants.API_V1_PREFIX + "/internal")
-@Profile({"dev","ci"})
 public class InternalTestController {
 
     /**
      * Простой эндпоинт, который должен быть доступен только с валидным API-ключом.
-     * @return Ответ 200 OK с простым сообщением.
+     * Возвращает ID сервиса и ID экземпляра, извлеченные из Authentication.
+     * @param apiKeyAuth Объект аутентификации, установленный фильтром.
+     * @return Ответ 200 OK с данными аутентификации.
      */
     @GetMapping("/test")
-    public ResponseEntity<String> testInternalEndpoint() {
-        return ResponseEntity.ok("Internal API endpoint reached successfully.");
+    public ResponseEntity<Map<String, String>> testInternalEndpoint(ApiKeyAuthentication apiKeyAuth) {
+
+        if (apiKeyAuth == null || !apiKeyAuth.isAuthenticated()) {
+            return ResponseEntity.status(500).body(Map.of("error", "Authentication object not found or not authenticated"));
+        }
+
+        return ResponseEntity.ok(Map.of(
+                "message", "Internal API endpoint reached successfully.",
+                "serviceId", apiKeyAuth.getServiceId(),
+                "instanceId", apiKeyAuth.getInstanceId()
+        ));
     }
 }

--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/web/exception/GlobalExceptionHandler.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/web/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.example.tasktracker.backend.web.exception;
 
+import com.example.tasktracker.backend.security.apikey.InvalidApiKeyException;
 import com.example.tasktracker.backend.security.exception.BadJwtException;
 import com.example.tasktracker.backend.security.jwt.JwtValidator;
 import com.example.tasktracker.backend.web.ApiConstants;
@@ -192,6 +193,36 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         problemDetail.setTitle(title);
         problemDetail.setDetail(detail);
         problemDetail.setType(URI.create(ApiConstants.PROBLEM_TYPE_BASE_URI + "auth/invalid-credentials"));
+
+        setInstanceUriIfAbsent(problemDetail, request);
+        return problemDetail;
+    }
+
+    /**
+     * Обрабатывает {@link InvalidApiKeyException}, возникающее при сбое
+     * M2M аутентификации по API-ключу.
+     * <p>
+     * Возвращает {@link ProblemDetail} для ответа HTTP 401 Unauthorized,
+     * но, в отличие от ошибок пользовательской аутентификации,
+     * **не устанавливает** заголовок {@code WWW-Authenticate}.
+     * </p>
+     *
+     * @param ex      Исключение {@link InvalidApiKeyException}.
+     * @param request Текущий веб-запрос.
+     * @return Объект {@link ProblemDetail}, описывающий ошибку.
+     */
+    @ExceptionHandler(InvalidApiKeyException.class)
+    public ProblemDetail handleInvalidApiKeyException(InvalidApiKeyException ex, WebRequest request) {
+        log.warn("API Key authentication failure: {}", ex.getMessage());
+
+        String typeSuffix = "auth.invalidApiKey";
+        String title = messageSource.getMessage("problemDetail." + typeSuffix + ".title", null, request.getLocale());
+        String detail = messageSource.getMessage("problemDetail." + typeSuffix + ".detail", null, request.getLocale());
+
+        ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.UNAUTHORIZED);
+        problemDetail.setTitle(title);
+        problemDetail.setDetail(detail);
+        problemDetail.setType(URI.create(ApiConstants.PROBLEM_TYPE_BASE_URI + "auth/invalid-api-key"));
 
         setInstanceUriIfAbsent(problemDetail, request);
         return problemDetail;

--- a/task-tracker-backend/src/main/resources/application-ci.yml
+++ b/task-tracker-backend/src/main/resources/application-ci.yml
@@ -31,3 +31,6 @@ app:
       # Пример Base64 ключа (реальный ключ должен быть сгенерирован и быть длиннее для HS256)
       # Это "myVerySecretKeyForTaskTrackerApplicationWhichMustBeVeryLongAndSecure" в Base64
       secret-key: "bXlWZXJ5U2VjcmV0S2V5Rm9yVGFza1RyYWNrZXJBcHBsaWNhdGlvbldoaWNoTXVzdEJlVmVyeUxvbmdBbmRTZWN1cmU="
+    api-key:
+      valid-keys:
+        - "ci-api-key-for-internal-services"

--- a/task-tracker-backend/src/main/resources/application-ci.yml
+++ b/task-tracker-backend/src/main/resources/application-ci.yml
@@ -34,4 +34,3 @@ app:
     api-key:
       keys-to-services:
         "key-for-scheduler": "task-tracker-scheduler"
-        "key-for-testing": "test-client"

--- a/task-tracker-backend/src/main/resources/application-ci.yml
+++ b/task-tracker-backend/src/main/resources/application-ci.yml
@@ -32,5 +32,6 @@ app:
       # Это "myVerySecretKeyForTaskTrackerApplicationWhichMustBeVeryLongAndSecure" в Base64
       secret-key: "bXlWZXJ5U2VjcmV0S2V5Rm9yVGFza1RyYWNrZXJBcHBsaWNhdGlvbldoaWNoTXVzdEJlVmVyeUxvbmdBbmRTZWN1cmU="
     api-key:
-      valid-keys:
-        - "ci-api-key-for-internal-services"
+      keys-to-services:
+        "key-for-scheduler": "task-tracker-scheduler"
+        "key-for-testing": "test-client"

--- a/task-tracker-backend/src/main/resources/application-dev.yml
+++ b/task-tracker-backend/src/main/resources/application-dev.yml
@@ -52,5 +52,6 @@ app:
       # Это "myVerySecretKeyForTaskTrackerApplicationWhichMustBeVeryLongAndSecure" в Base64
       secret-key: "bXlWZXJ5U2VjcmV0S2V5Rm9yVGFza1RyYWNrZXJBcHBsaWNhdGlvbldoaWNoTXVzdEJlVmVyeUxvbmdBbmRTZWN1cmU="
     api-key:
-      valid-keys:
-        - "dev-api-key-for-internal-services"
+      keys-to-services:
+        "key-for-scheduler": "task-tracker-scheduler"
+        "key-for-testing": "test-client"

--- a/task-tracker-backend/src/main/resources/application-dev.yml
+++ b/task-tracker-backend/src/main/resources/application-dev.yml
@@ -51,3 +51,6 @@ app:
       # Пример Base64 ключа (реальный ключ должен быть сгенерирован и быть длиннее для HS256)
       # Это "myVerySecretKeyForTaskTrackerApplicationWhichMustBeVeryLongAndSecure" в Base64
       secret-key: "bXlWZXJ5U2VjcmV0S2V5Rm9yVGFza1RyYWNrZXJBcHBsaWNhdGlvbldoaWNoTXVzdEJlVmVyeUxvbmdBbmRTZWN1cmU="
+    api-key:
+      valid-keys:
+        - "dev-api-key-for-internal-services"

--- a/task-tracker-backend/src/main/resources/application-dev.yml
+++ b/task-tracker-backend/src/main/resources/application-dev.yml
@@ -54,4 +54,3 @@ app:
     api-key:
       keys-to-services:
         "key-for-scheduler": "task-tracker-scheduler"
-        "key-for-testing": "test-client"

--- a/task-tracker-backend/src/main/resources/i18n/security/messages.properties
+++ b/task-tracker-backend/src/main/resources/i18n/security/messages.properties
@@ -3,11 +3,12 @@
 # (Covers JWT, Auth, Security-related Problem Details)
 # =======================================================
 
-# --- Validation Messages for ConfigurationProperties (JwtProperties.java) ---
+# --- Validation Messages for Security Properties ---
 security.jwt.secretKey.notBlank=JWT secret key must not be blank and must be provided in Base64 format.
 security.jwt.expirationMs.positive=JWT expiration time in milliseconds must be a positive number.
 security.jwt.claims.emailKey.notBlank=Configuration for JWT email claim key must not be blank.
 security.jwt.claims.authoritiesKey.notBlank=Configuration for JWT authorities claim key must not be blank.
+security.apiKey.keysToServices.notEmpty=At least one API key-to-service mapping must be configured.
 
 # --- Problem Details: JWT Errors (BadJwtException) ---
 problemDetail.jwt.expired.title=Expired Token

--- a/task-tracker-backend/src/main/resources/i18n/security/messages.properties
+++ b/task-tracker-backend/src/main/resources/i18n/security/messages.properties
@@ -39,6 +39,10 @@ problemDetail.unauthorized.detail=Full authentication is required to access this
 problemDetail.auth.invalidCredentials.title=Invalid Credentials
 problemDetail.auth.invalidCredentials.detail=The email or password provided is incorrect.
 
+# --- Problem Details: M2M Authentication Errors (InvalidApiKeyException) ---
+problemDetail.auth.invalidApiKey.title=Invalid API Key
+problemDetail.auth.invalidApiKey.detail=The provided API Key is missing or invalid.
+
 # --- Problem Details: Authorization Errors (AccessDeniedException) ---
 problemDetail.forbidden.title=Access Denied
 problemDetail.forbidden.detail=You do not have the necessary permissions to access this resource or perform this action.

--- a/task-tracker-backend/src/test/java/com/example/tasktracker/backend/security/apikey/ApiKeyPropertiesIT.java
+++ b/task-tracker-backend/src/test/java/com/example/tasktracker/backend/security/apikey/ApiKeyPropertiesIT.java
@@ -1,0 +1,60 @@
+package com.example.tasktracker.backend.security.apikey;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Интеграционные тесты для {@link ApiKeyProperties}, проверяющие
+ * корректность биндинга и валидации свойств из конфигурации.
+ */
+@ActiveProfiles("ci")
+class ApiKeyPropertiesIT {
+
+    @Configuration
+    @EnableConfigurationProperties(ApiKeyProperties.class)
+    static class TestConfig {
+    }
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withUserConfiguration(TestConfig.class);
+
+    @Test
+    @DisplayName("Конфигурация: валидные ключи -> контекст загружается, свойства корректны")
+    void properties_whenKeysAreValid_shouldLoadContextAndBindProperties() {
+        this.contextRunner
+                .withPropertyValues(
+                        "app.security.api-key.valid-keys[0]=key-for-scheduler",
+                        "app.security.api-key.valid-keys[1]=key-for-another-service"
+                )
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    assertThat(context).hasSingleBean(ApiKeyProperties.class);
+
+                    ApiKeyProperties props = context.getBean(ApiKeyProperties.class);
+                    assertThat(props.getValidKeys())
+                            .isNotNull()
+                            .hasSize(2)
+                            .contains("key-for-scheduler", "key-for-another-service");
+                });
+    }
+
+    @Test
+    @DisplayName("Конфигурация: valid-keys отсутствует -> валидация должна упасть")
+    void properties_whenKeysAreMissing_shouldFailToLoadContext() {
+        this.contextRunner.run(context -> assertThat(context).hasFailed());
+    }
+
+    @Test
+    @DisplayName("Конфигурация: valid-keys пустой -> валидация (@NotEmpty) должна упасть")
+    void properties_whenKeysAreEmpty_shouldFailToLoadContext() {
+        this.contextRunner
+                .withPropertyValues("app.security.api-key.valid-keys=")
+                .run(context -> assertThat(context).hasFailed());
+    }
+}

--- a/task-tracker-backend/src/test/java/com/example/tasktracker/backend/security/apikey/ApiKeyValidatorTest.java
+++ b/task-tracker-backend/src/test/java/com/example/tasktracker/backend/security/apikey/ApiKeyValidatorTest.java
@@ -1,0 +1,78 @@
+package com.example.tasktracker.backend.security.apikey;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+
+/**
+ * Юнит-тесты для {@link ApiKeyValidator}.
+ */
+@ExtendWith(MockitoExtension.class)
+class ApiKeyValidatorTest {
+
+    @Mock
+    private ApiKeyProperties mockApiKeyProperties;
+
+    @InjectMocks
+    private ApiKeyValidator apiKeyValidator;
+
+    private final String validKey1 = "my-secret-key-1";
+    private final String validKey2 = "my-secret-key-2";
+
+    @BeforeEach
+    void setUp() {
+        // Настраиваем мок по умолчанию для большинства тестов
+        lenient().when(mockApiKeyProperties.getValidKeys()).thenReturn(Set.of(validKey1, validKey2));
+    }
+
+    @Test
+    @DisplayName("isValid: предоставленный ключ совпадает с одним из валидных -> должен вернуть true")
+    void isValid_whenProvidedKeyMatches_shouldReturnTrue() {
+        assertThat(apiKeyValidator.isValid(validKey1)).isTrue();
+        assertThat(apiKeyValidator.isValid(validKey2)).isTrue();
+    }
+
+    @Test
+    @DisplayName("isValid: предоставленный ключ не совпадает ни с одним из валидных -> должен вернуть false")
+    void isValid_whenProvidedKeyDoesNotMatch_shouldReturnFalse() {
+        assertThat(apiKeyValidator.isValid("invalid-key")).isFalse();
+    }
+
+    @Test
+    @DisplayName("isValid: предоставленный ключ null -> должен выбросить NullPointerException")
+    void isValid_whenProvidedKeyIsNull_shouldThrowNullPointerException() {
+        assertThatNullPointerException()
+                .isThrownBy(() -> apiKeyValidator.isValid(null))
+                .withMessageContaining("providedKey");
+    }
+
+    @Test
+    @DisplayName("isValid: набор валидных ключей пуст -> должен всегда возвращать false")
+    void isValid_whenValidKeysSetIsEmpty_shouldAlwaysReturnFalse() {
+        when(mockApiKeyProperties.getValidKeys()).thenReturn(Collections.emptySet());
+        assertThat(apiKeyValidator.isValid(validKey1)).isFalse();
+        assertThat(apiKeyValidator.isValid("any-key")).isFalse();
+    }
+
+    @Test
+    @DisplayName("isValid: набор валидных ключей null -> должен вернуть false и залогировать ошибку")
+    void isValid_whenValidKeysSetIsNull_shouldReturnFalseAndLogCriticalError() {
+        // Этот тест важен для проверки защиты от неправильной конфигурации,
+        // хотя @NotEmpty в ApiKeyProperties должен предотвращать это на старте.
+        when(mockApiKeyProperties.getValidKeys()).thenReturn(null);
+        assertThat(apiKeyValidator.isValid(validKey1)).isFalse();
+    }
+}

--- a/task-tracker-backend/src/test/java/com/example/tasktracker/backend/security/filter/ApiKeyAuthenticationFilterTest.java
+++ b/task-tracker-backend/src/test/java/com/example/tasktracker/backend/security/filter/ApiKeyAuthenticationFilterTest.java
@@ -1,5 +1,6 @@
 package com.example.tasktracker.backend.security.filter;
 
+import com.example.tasktracker.backend.common.MdcKeys;
 import com.example.tasktracker.backend.security.apikey.ApiKeyAuthentication;
 import com.example.tasktracker.backend.security.apikey.ApiKeyValidator;
 import jakarta.servlet.FilterChain;
@@ -14,67 +15,104 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.MDC;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.AuthenticationEntryPoint;
 
 import java.io.IOException;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class ApiKeyAuthenticationFilterTest {
 
-    @Mock
-    private ApiKeyValidator mockApiKeyValidator;
-    @Mock
-    private AuthenticationEntryPoint mockAuthenticationEntryPoint;
-    @Mock
-    private HttpServletRequest mockRequest;
-    @Mock
-    private HttpServletResponse mockResponse;
-    @Mock
-    private FilterChain mockFilterChain;
+    @Mock private ApiKeyValidator mockApiKeyValidator;
+    @Mock private AuthenticationEntryPoint mockAuthenticationEntryPoint;
+    @Mock private HttpServletRequest mockRequest;
+    @Mock private HttpServletResponse mockResponse;
+    @Mock private FilterChain mockFilterChain;
 
     @InjectMocks
     private ApiKeyAuthenticationFilter apiKeyAuthenticationFilter;
 
     @BeforeEach
     @AfterEach
-    void clearSecurityContext() {
+    void clearSecurityContextAndMdc() {
         SecurityContextHolder.clearContext();
+        MDC.clear();
     }
 
     @Test
-    @DisplayName("doFilterInternal: Валидный API ключ -> должен установить Authentication и продолжить цепочку")
-    void doFilterInternal_whenValidApiKey_shouldSetAuthenticationAndProceedChain() throws ServletException, IOException {
+    @DisplayName("doFilterInternal: валидный API ключ и заголовок экземпляра -> должен установить Authentication и MDC")
+    void doFilterInternal_whenValidKeyAndInstanceHeader_shouldSetAuthAndMdc() throws ServletException, IOException {
         // Arrange
-        String validKey = "valid-key-123";
+        String validKey = "valid-key";
+        String serviceId = "scheduler-service";
+        String instanceId = "scheduler-pod-123";
         when(mockRequest.getHeader("X-API-Key")).thenReturn(validKey);
-        when(mockApiKeyValidator.isValid(validKey)).thenReturn(true);
+        when(mockRequest.getHeader("X-Service-Instance-Id")).thenReturn(instanceId);
+        when(mockApiKeyValidator.getServiceIdIfValid(validKey)).thenReturn(Optional.of(serviceId));
+
+        doAnswer(invocation -> {
+            assertThat(MDC.get(MdcKeys.SERVICE_ID)).isEqualTo(serviceId);
+            assertThat(MDC.get(MdcKeys.SERVICE_INSTANCE_ID)).isEqualTo(instanceId);
+            return null;
+        }).when(mockFilterChain).doFilter(mockRequest, mockResponse);
 
         // Act
         apiKeyAuthenticationFilter.doFilterInternal(mockRequest, mockResponse, mockFilterChain);
 
         // Assert
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        assertThat(authentication).isNotNull().isInstanceOf(ApiKeyAuthentication.class);
-        assertThat(authentication.isAuthenticated()).isTrue();
-        assertThat(authentication.getPrincipal()).isEqualTo("internal-service");
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(auth).isInstanceOf(ApiKeyAuthentication.class);
+        ApiKeyAuthentication apiKeyAuth = (ApiKeyAuthentication) auth;
+        assertThat(apiKeyAuth.getServiceId()).isEqualTo(serviceId);
+        assertThat(apiKeyAuth.getInstanceId()).isEqualTo(instanceId);
+
+        verify(mockFilterChain).doFilter(mockRequest, mockResponse);
+        verifyNoInteractions(mockAuthenticationEntryPoint);
+        assertThat(MDC.get(MdcKeys.SERVICE_ID)).isNull(); // Проверяем очистку
+        assertThat(MDC.get(MdcKeys.SERVICE_INSTANCE_ID)).isNull();
+    }
+
+    @Test
+    @DisplayName("doFilterInternal: валидный API ключ, но отсутствует заголовок экземпляра -> должен использовать placeholder")
+    void doFilterInternal_whenValidKeyButMissingInstanceHeader_shouldUsePlaceholder() throws ServletException, IOException {
+        // Arrange
+        String validKey = "valid-key";
+        String serviceId = "scheduler-service";
+        when(mockRequest.getHeader("X-API-Key")).thenReturn(validKey);
+        when(mockRequest.getHeader("X-Service-Instance-Id")).thenReturn(null); // Заголовок отсутствует
+        when(mockApiKeyValidator.getServiceIdIfValid(validKey)).thenReturn(Optional.of(serviceId));
+
+        doAnswer(invocation -> {
+            assertThat(MDC.get(MdcKeys.SERVICE_INSTANCE_ID)).isEqualTo(ApiKeyAuthenticationFilter.UNKNOWN_INSTANCE_ID);
+            return null;
+        }).when(mockFilterChain).doFilter(mockRequest, mockResponse);
+
+        // Act
+        apiKeyAuthenticationFilter.doFilterInternal(mockRequest, mockResponse, mockFilterChain);
+
+        // Assert
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(auth).isInstanceOf(ApiKeyAuthentication.class);
+        ApiKeyAuthentication apiKeyAuth = (ApiKeyAuthentication) auth;
+        assertThat(apiKeyAuth.getInstanceId()).isEqualTo(ApiKeyAuthenticationFilter.UNKNOWN_INSTANCE_ID);
 
         verify(mockFilterChain).doFilter(mockRequest, mockResponse);
         verifyNoInteractions(mockAuthenticationEntryPoint);
     }
 
     @Test
-    @DisplayName("doFilterInternal: Невалидный API ключ -> должен вызвать AuthenticationEntryPoint и прервать цепочку")
-    void doFilterInternal_whenInvalidApiKey_shouldCallEntryPointAndStopChain() throws ServletException, IOException {
+    @DisplayName("doFilterInternal: Невалидный API ключ -> должен вызвать AuthenticationEntryPoint")
+    void doFilterInternal_whenInvalidApiKey_shouldCallEntryPoint() throws ServletException, IOException {
         // Arrange
-        String invalidKey = "invalid-key-456";
+        String invalidKey = "invalid-key";
         when(mockRequest.getHeader("X-API-Key")).thenReturn(invalidKey);
-        when(mockApiKeyValidator.isValid(invalidKey)).thenReturn(false);
+        when(mockApiKeyValidator.getServiceIdIfValid(invalidKey)).thenReturn(Optional.empty());
 
         // Act
         apiKeyAuthenticationFilter.doFilterInternal(mockRequest, mockResponse, mockFilterChain);
@@ -83,21 +121,5 @@ class ApiKeyAuthenticationFilterTest {
         assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
         verify(mockAuthenticationEntryPoint).commence(eq(mockRequest), eq(mockResponse), any());
         verify(mockFilterChain, never()).doFilter(mockRequest, mockResponse);
-    }
-
-    @Test
-    @DisplayName("doFilterInternal: Отсутствует заголовок с API ключом -> должен вызвать AuthenticationEntryPoint и прервать цепочку")
-    void doFilterInternal_whenApiKeyHeaderIsMissing_shouldCallEntryPointAndStopChain() throws ServletException, IOException {
-        // Arrange
-        when(mockRequest.getHeader("X-API-Key")).thenReturn(null);
-
-        // Act
-        apiKeyAuthenticationFilter.doFilterInternal(mockRequest, mockResponse, mockFilterChain);
-
-        // Assert
-        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
-        verify(mockAuthenticationEntryPoint).commence(eq(mockRequest), eq(mockResponse), any());
-        verify(mockFilterChain, never()).doFilter(mockRequest, mockResponse);
-        verifyNoInteractions(mockApiKeyValidator); // Валидатор не должен вызываться, если ключа нет
     }
 }

--- a/task-tracker-backend/src/test/java/com/example/tasktracker/backend/security/filter/ApiKeyAuthenticationFilterTest.java
+++ b/task-tracker-backend/src/test/java/com/example/tasktracker/backend/security/filter/ApiKeyAuthenticationFilterTest.java
@@ -1,0 +1,103 @@
+package com.example.tasktracker.backend.security.filter;
+
+import com.example.tasktracker.backend.security.apikey.ApiKeyAuthentication;
+import com.example.tasktracker.backend.security.apikey.ApiKeyValidator;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ApiKeyAuthenticationFilterTest {
+
+    @Mock
+    private ApiKeyValidator mockApiKeyValidator;
+    @Mock
+    private AuthenticationEntryPoint mockAuthenticationEntryPoint;
+    @Mock
+    private HttpServletRequest mockRequest;
+    @Mock
+    private HttpServletResponse mockResponse;
+    @Mock
+    private FilterChain mockFilterChain;
+
+    @InjectMocks
+    private ApiKeyAuthenticationFilter apiKeyAuthenticationFilter;
+
+    @BeforeEach
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("doFilterInternal: Валидный API ключ -> должен установить Authentication и продолжить цепочку")
+    void doFilterInternal_whenValidApiKey_shouldSetAuthenticationAndProceedChain() throws ServletException, IOException {
+        // Arrange
+        String validKey = "valid-key-123";
+        when(mockRequest.getHeader("X-API-Key")).thenReturn(validKey);
+        when(mockApiKeyValidator.isValid(validKey)).thenReturn(true);
+
+        // Act
+        apiKeyAuthenticationFilter.doFilterInternal(mockRequest, mockResponse, mockFilterChain);
+
+        // Assert
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(authentication).isNotNull().isInstanceOf(ApiKeyAuthentication.class);
+        assertThat(authentication.isAuthenticated()).isTrue();
+        assertThat(authentication.getPrincipal()).isEqualTo("internal-service");
+
+        verify(mockFilterChain).doFilter(mockRequest, mockResponse);
+        verifyNoInteractions(mockAuthenticationEntryPoint);
+    }
+
+    @Test
+    @DisplayName("doFilterInternal: Невалидный API ключ -> должен вызвать AuthenticationEntryPoint и прервать цепочку")
+    void doFilterInternal_whenInvalidApiKey_shouldCallEntryPointAndStopChain() throws ServletException, IOException {
+        // Arrange
+        String invalidKey = "invalid-key-456";
+        when(mockRequest.getHeader("X-API-Key")).thenReturn(invalidKey);
+        when(mockApiKeyValidator.isValid(invalidKey)).thenReturn(false);
+
+        // Act
+        apiKeyAuthenticationFilter.doFilterInternal(mockRequest, mockResponse, mockFilterChain);
+
+        // Assert
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        verify(mockAuthenticationEntryPoint).commence(eq(mockRequest), eq(mockResponse), any());
+        verify(mockFilterChain, never()).doFilter(mockRequest, mockResponse);
+    }
+
+    @Test
+    @DisplayName("doFilterInternal: Отсутствует заголовок с API ключом -> должен вызвать AuthenticationEntryPoint и прервать цепочку")
+    void doFilterInternal_whenApiKeyHeaderIsMissing_shouldCallEntryPointAndStopChain() throws ServletException, IOException {
+        // Arrange
+        when(mockRequest.getHeader("X-API-Key")).thenReturn(null);
+
+        // Act
+        apiKeyAuthenticationFilter.doFilterInternal(mockRequest, mockResponse, mockFilterChain);
+
+        // Assert
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        verify(mockAuthenticationEntryPoint).commence(eq(mockRequest), eq(mockResponse), any());
+        verify(mockFilterChain, never()).doFilter(mockRequest, mockResponse);
+        verifyNoInteractions(mockApiKeyValidator); // Валидатор не должен вызываться, если ключа нет
+    }
+}

--- a/task-tracker-backend/src/test/java/com/example/tasktracker/backend/security/web/controller/InternalApiSecurityIT.java
+++ b/task-tracker-backend/src/test/java/com/example/tasktracker/backend/security/web/controller/InternalApiSecurityIT.java
@@ -1,20 +1,30 @@
 package com.example.tasktracker.backend.security.web.controller;
 
+import com.example.tasktracker.backend.security.apikey.ApiKeyProperties;
 import com.example.tasktracker.backend.security.filter.ApiKeyAuthenticationFilter;
+import com.example.tasktracker.backend.security.jwt.JwtProperties;
+import com.example.tasktracker.backend.test.util.TestJwtUtil;
+import com.example.tasktracker.backend.user.entity.User;
+import com.example.tasktracker.backend.user.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.*;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.Clock;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -31,34 +41,75 @@ class InternalApiSecurityIT {
     @LocalServerPort
     private int port;
 
-    @Autowired
-    private TestRestTemplate testRestTemplate;
-
-    @Value("${app.security.api-key.valid-keys[0]}")
-    private String validApiKey; // Получаем ключ из application-ci.yml
+    @Autowired private TestRestTemplate testRestTemplate;
+    @Autowired private ApiKeyProperties apiKeyProperties;
+    @Autowired private UserRepository userRepository; // Для создания пользователя для JWT
+    @Autowired private PasswordEncoder passwordEncoder;
+    @Autowired private JwtProperties jwtProperties;
+    @Autowired private Clock clock;
 
     private String baseUrl;
+    private String validApiKeyForScheduler;
+    private TestJwtUtil testJwtUtil;
+    private User testUser;
 
     @BeforeEach
     void setUp() {
+        userRepository.deleteAllInBatch();
+        testUser = userRepository.save(new User(null, "jwt-user@test.com", passwordEncoder.encode("pass"), null, null));
+        testJwtUtil = new TestJwtUtil(jwtProperties, clock);
+
+        validApiKeyForScheduler = apiKeyProperties.getKeysToServices().entrySet().stream()
+                .filter(entry -> "task-tracker-scheduler".equals(entry.getValue()))
+                .map(Map.Entry::getKey)
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("API Key for 'task-tracker-scheduler' not found in test configuration"));
         baseUrl = "http://localhost:" + port + "/api/v1/internal";
     }
 
+    @AfterEach
+    void tearDown() {
+        userRepository.deleteAllInBatch();
+    }
+
     @Test
-    @DisplayName("Запрос к /internal с валидным API ключом -> должен вернуть 200 OK")
-    void requestToInternal_withValidApiKey_shouldReturn200() {
+    @DisplayName("Запрос к /internal с валидным ключом и ID экземпляра -> должен вернуть 200 OK и данные сервиса")
+    void requestToInternal_withValidKeyAndInstanceId_shouldReturn200AndServiceData() {
         // Arrange
         HttpHeaders headers = new HttpHeaders();
-        headers.set(ApiKeyAuthenticationFilter.API_KEY_HEADER_NAME, validApiKey);
+        headers.set(ApiKeyAuthenticationFilter.API_KEY_HEADER_NAME, validApiKeyForScheduler);
+        headers.set(ApiKeyAuthenticationFilter.SERVICE_INSTANCE_ID_HEADER_NAME, "scheduler-pod-1");
         HttpEntity<String> entity = new HttpEntity<>(headers);
 
         // Act
-        ResponseEntity<String> response = testRestTemplate.exchange(
-                baseUrl + "/test", HttpMethod.GET, entity, String.class);
+        ResponseEntity<Map<String, String>> response = testRestTemplate.exchange(
+                baseUrl + "/test", HttpMethod.GET, entity, new ParameterizedTypeReference<>() {});
 
         // Assert
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(response.getBody()).isEqualTo("Internal API endpoint reached successfully.");
+        assertThat(response.getBody())
+                .containsEntry("serviceId", "task-tracker-scheduler")
+                .containsEntry("instanceId", "scheduler-pod-1");
+    }
+
+    @Test
+    @DisplayName("Запрос к /internal с валидным ключом, но без ID экземпляра -> должен вернуть 200 OK и placeholder")
+    void requestToInternal_withValidKeyAndNoInstanceId_shouldReturn200AndPlaceholder() {
+        // Arrange
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(ApiKeyAuthenticationFilter.API_KEY_HEADER_NAME, validApiKeyForScheduler);
+        // Заголовок X-Service-Instance-Id не установлен
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        // Act
+        ResponseEntity<Map<String, String>> response = testRestTemplate.exchange(
+                baseUrl + "/test", HttpMethod.GET, entity, new ParameterizedTypeReference<>() {});
+
+        // Assert
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody())
+                .containsEntry("serviceId", "task-tracker-scheduler")
+                .containsEntry("instanceId", ApiKeyAuthenticationFilter.UNKNOWN_INSTANCE_ID);
     }
 
     @Test
@@ -75,8 +126,6 @@ class InternalApiSecurityIT {
 
         // Assert
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
-        assertThat(response.getBody()).isNotNull();
-        assertThat(response.getBody().getTitle()).isEqualTo("Invalid Credentials"); // Ожидаем ошибку от AuthSvc
     }
 
     @Test
@@ -91,25 +140,46 @@ class InternalApiSecurityIT {
 
         // Assert
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
-        assertThat(response.getBody()).isNotNull();
-        assertThat(response.getBody().getTitle()).isEqualTo("Invalid Credentials");
     }
 
     @Test
-    @DisplayName("Запрос к публичному API с API ключом -> должен вернуть 401 (т.к. нужен JWT)")
-    void requestToPublicApi_withApiKey_shouldReturn401() {
+    @DisplayName("Запрос к /internal с валидным JWT, но без API ключа -> должен вернуть 401")
+    void requestToInternal_withValidJwtButNoApiKey_shouldReturn401() {
         // Arrange
+        String validJwt = testJwtUtil.generateValidToken(testUser);
         HttpHeaders headers = new HttpHeaders();
-        headers.set(ApiKeyAuthenticationFilter.API_KEY_HEADER_NAME, validApiKey);
+        headers.setBearerAuth(validJwt); // Только JWT
         HttpEntity<String> entity = new HttpEntity<>(headers);
-        String publicApiUrl = "http://localhost:" + port + "/api/v1/users/me";
 
         // Act
         ResponseEntity<ProblemDetail> response = testRestTemplate.exchange(
-                publicApiUrl, HttpMethod.GET, entity, ProblemDetail.class);
+                baseUrl + "/test", HttpMethod.GET, entity, ProblemDetail.class);
 
         // Assert
+        // Ожидаем ошибку от ApiKey-цепочки, так как она первая для этого пути
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
-        assertThat(response.getBody().getTitle()).isEqualTo("Authentication Required"); // Ожидаем ошибку от JWT-цепочки
+
+        assertThat(response.getBody().getProperties()).isNull();
+    }
+
+    @Test
+    @DisplayName("Запрос к /internal с валидным API ключом и валидным JWT -> должен вернуть 200 OK (API ключ имеет приоритет)")
+    void requestToInternal_withValidApiKeyAndValidJwt_shouldReturn200() {
+        // Arrange
+        String validJwt = testJwtUtil.generateValidToken(testUser);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(validJwt); // JWT есть
+        headers.set(ApiKeyAuthenticationFilter.API_KEY_HEADER_NAME, validApiKeyForScheduler); // И API ключ есть
+        headers.set(ApiKeyAuthenticationFilter.SERVICE_INSTANCE_ID_HEADER_NAME, "mixed-auth-test-1");
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        // Act
+        ResponseEntity<Map<String, String>> response = testRestTemplate.exchange(
+                baseUrl + "/test", HttpMethod.GET, entity, new ParameterizedTypeReference<>() {});
+
+        // Assert
+        // ApiKey-цепочка должна сработать и пропустить запрос. JWT должен быть проигнорирован.
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).containsEntry("serviceId", "task-tracker-scheduler");
     }
 }

--- a/task-tracker-backend/src/test/java/com/example/tasktracker/backend/security/web/controller/InternalApiSecurityIT.java
+++ b/task-tracker-backend/src/test/java/com/example/tasktracker/backend/security/web/controller/InternalApiSecurityIT.java
@@ -43,7 +43,7 @@ class InternalApiSecurityIT {
 
     @Autowired private TestRestTemplate testRestTemplate;
     @Autowired private ApiKeyProperties apiKeyProperties;
-    @Autowired private UserRepository userRepository; // Для создания пользователя для JWT
+    @Autowired private UserRepository userRepository;
     @Autowired private PasswordEncoder passwordEncoder;
     @Autowired private JwtProperties jwtProperties;
     @Autowired private Clock clock;
@@ -126,6 +126,7 @@ class InternalApiSecurityIT {
 
         // Assert
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        assertThat(response.getBody().getType().getPath()).contains("auth/invalid-api-key");
     }
 
     @Test
@@ -140,6 +141,7 @@ class InternalApiSecurityIT {
 
         // Assert
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        assertThat(response.getBody().getType().getPath()).contains("auth/invalid-api-key");
     }
 
     @Test
@@ -158,8 +160,7 @@ class InternalApiSecurityIT {
         // Assert
         // Ожидаем ошибку от ApiKey-цепочки, так как она первая для этого пути
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
-
-        assertThat(response.getBody().getProperties()).isNull();
+        assertThat(response.getBody().getType().getPath()).contains("auth/invalid-api-key");
     }
 
     @Test

--- a/task-tracker-backend/src/test/java/com/example/tasktracker/backend/security/web/controller/InternalApiSecurityIT.java
+++ b/task-tracker-backend/src/test/java/com/example/tasktracker/backend/security/web/controller/InternalApiSecurityIT.java
@@ -1,0 +1,115 @@
+package com.example.tasktracker.backend.security.web.controller;
+
+import com.example.tasktracker.backend.security.filter.ApiKeyAuthenticationFilter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.http.*;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Testcontainers
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("ci")
+class InternalApiSecurityIT {
+
+    @Container
+    @ServiceConnection
+    static final PostgreSQLContainer<?> postgresContainer =
+            new PostgreSQLContainer<>("postgres:17.4-alpine");
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate testRestTemplate;
+
+    @Value("${app.security.api-key.valid-keys[0]}")
+    private String validApiKey; // Получаем ключ из application-ci.yml
+
+    private String baseUrl;
+
+    @BeforeEach
+    void setUp() {
+        baseUrl = "http://localhost:" + port + "/api/v1/internal";
+    }
+
+    @Test
+    @DisplayName("Запрос к /internal с валидным API ключом -> должен вернуть 200 OK")
+    void requestToInternal_withValidApiKey_shouldReturn200() {
+        // Arrange
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(ApiKeyAuthenticationFilter.API_KEY_HEADER_NAME, validApiKey);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        // Act
+        ResponseEntity<String> response = testRestTemplate.exchange(
+                baseUrl + "/test", HttpMethod.GET, entity, String.class);
+
+        // Assert
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo("Internal API endpoint reached successfully.");
+    }
+
+    @Test
+    @DisplayName("Запрос к /internal с невалидным API ключом -> должен вернуть 401 Unauthorized")
+    void requestToInternal_withInvalidApiKey_shouldReturn401() {
+        // Arrange
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(ApiKeyAuthenticationFilter.API_KEY_HEADER_NAME, "invalid-api-key-value");
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        // Act
+        ResponseEntity<ProblemDetail> response = testRestTemplate.exchange(
+                baseUrl + "/test", HttpMethod.GET, entity, ProblemDetail.class);
+
+        // Assert
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getTitle()).isEqualTo("Invalid Credentials"); // Ожидаем ошибку от AuthSvc
+    }
+
+    @Test
+    @DisplayName("Запрос к /internal без API ключа -> должен вернуть 401 Unauthorized")
+    void requestToInternal_withoutApiKey_shouldReturn401() {
+        // Arrange
+        HttpEntity<String> entity = new HttpEntity<>(new HttpHeaders());
+
+        // Act
+        ResponseEntity<ProblemDetail> response = testRestTemplate.exchange(
+                baseUrl + "/test", HttpMethod.GET, entity, ProblemDetail.class);
+
+        // Assert
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getTitle()).isEqualTo("Invalid Credentials");
+    }
+
+    @Test
+    @DisplayName("Запрос к публичному API с API ключом -> должен вернуть 401 (т.к. нужен JWT)")
+    void requestToPublicApi_withApiKey_shouldReturn401() {
+        // Arrange
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(ApiKeyAuthenticationFilter.API_KEY_HEADER_NAME, validApiKey);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+        String publicApiUrl = "http://localhost:" + port + "/api/v1/users/me";
+
+        // Act
+        ResponseEntity<ProblemDetail> response = testRestTemplate.exchange(
+                publicApiUrl, HttpMethod.GET, entity, ProblemDetail.class);
+
+        // Assert
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        assertThat(response.getBody().getTitle()).isEqualTo("Authentication Required"); // Ожидаем ошибку от JWT-цепочки
+    }
+}


### PR DESCRIPTION
### **Описание (Description)**

Этот Pull Request решает задачу **API-SCHED-01.1** и связанные с ней доработки. Он внедряет надежный и изолированный механизм аутентификации для внутренних, межсервисных (M2M) вызовов, защищая новое пространство имен API `/api/v1/internal/**`.

Главное нововведение — это введение **аутентификации по статическому API-ключу**. Архитектура была итеративно улучшена, чтобы обеспечить не только безопасность, но и высокую наблюдаемость и семантическую корректность ответов API.

**Ключевые изменения и улучшения:**

*   **Изолированные цепочки фильтров:** `SecurityConfig` был полностью рефакторен для использования нескольких, упорядоченных и взаимоисключающих бинов `SecurityFilterChain`, что гарантирует, что запросы к внутренним API обрабатываются отдельной, более строгой цепочкой фильтров.
*   **Идентификация сервиса и экземпляра:** Внутренняя аутентификация теперь требует два заголовка: `X-API-Key` (для аутентификации типа сервиса) и `X-Service-Instance-Id` (для идентификации конкретного экземпляра).
*   **Обогащение логов (MDC):** После успешной M2M-аутентификации, идентификаторы `serviceId` и `instanceId` помещаются в Mapped Diagnostic Context (MDC), что автоматически обогащает все последующие логи для данного запроса.
*   **Семантически верная обработка ошибок:** Внедрено новое исключение `InvalidApiKeyException` и соответствующий обработчик в `GlobalExceptionHandler`. Это **разделяет обработку ошибок аутентификации M2M от ошибок пользовательской аутентификации**, гарантируя, что M2M-клиенты получают корректные `ProblemDetail` ответы без неуместных заголовков (`WWW-Authenticate: Bearer`).

### **Реализованный функционал (Implemented Functionality)**

*   **Новая схема аутентификации для `/api/v1/internal/**`:**
    *   **Заголовок `X-API-Key`:** Обязателен.
    *   **Заголовок `X-Service-Instance-Id`:** Обязателен.
*   **Новые компоненты безопасности:**
    *   `ApiKeyProperties`, `ApiKeyValidator`, `ApiKeyAuthenticationFilter`.
    *   `InvalidApiKeyException`: Новое исключение для семантически верной обработки ошибок API-ключей.
*   **Обновленная конфигурация:**
    *   `SecurityConfig` разделен на два `SecurityFilterChain` с `@Order` и `RequestMatcher`.
    *   `GlobalExceptionHandler` дополнен новым обработчиком для `InvalidApiKeyException`.

### **Критерии Приемки (Acceptance Criteria Checklist)**

*   [x] **AC1: Создан `ApiKeyAuthFilter`:** Фильтр реализован и интегрирован.
*   [x] **AC2: Конфигурация через `@ConfigurationProperties`:** `ApiKeyProperties` корректно читает карту ключей.
*   [x] **AC3: `SecurityConfig` разделен:** Существуют две независимые и взаимоисключающие цепочки фильтров.
*   [x] **AC4: Обработка ошибок:**
    *   [x] Запросы к `/internal/**` без ключа или с неверным ключом возвращают `401 Unauthorized`.
    *   [x] Тело ответа для ошибки API-ключа имеет `type: .../auth/invalid-api-key`.
    *   [x] Ответ **не содержит** заголовок `WWW-Authenticate: Bearer`.
*   [x] **AC5: Идентификация экземпляра и обогащение MDC:** Запрос с валидными заголовками успешно аутентифицируется, и `serviceId`/`instanceId` попадают в MDC.
*   [x] **AC6: Изоляция цепочек (тесты на регрессию):** Проверены все сценарии перекрестной аутентификации.

### **Соответствие Definition of Done (DoD Checklist)**

*   [x] Код написан и соответствует стандартам проекта.
*   [x] Javadoc написан/обновлен для всех новых и измененных компонентов.
*   [x] Реализованы все AC для задачи `API-SCHED-01.1`.
*   [x] Юнит-тесты написаны/обновлены.
*   [x] Интеграционные тесты написаны/обновлены, включая проверку специфичных `ProblemDetail`.
*   [x] Покрытие кода тестами (JaCoCo) проверено.
*   [ ] Код успешно прошел Code Review.
*   [x] CI/CD пайплайн (Jenkins) успешно проходит для этого кода.
*   [x] Документация (ADR-0039) создана.
*   [x] Новых критических технических задач или техдолга не выявлено.

### **Как тестировать (How to Test Manually)**

1.  **Тест 1 (Успех):** Отправить `GET`-запрос на `http://localhost:{port}/api/v1/internal/test` с валидными заголовками `X-API-Key` и `X-Service-Instance-Id`.
    *   **Ожидаемый результат:** `200 OK`.
2.  **Тест 2 (Невалидный ключ):** Отправить тот же запрос, но с неверным `X-API-Key`.
    *   **Ожидаемый результат:** `401 Unauthorized` с `ProblemDetail`, у которого `type` URI заканчивается на `/auth/invalid-api-key`. Заголовок `WWW-Authenticate` **отсутствует**.
3.  **Тест 3 (Проверка изоляции):** Отправить `POST`-запрос на `http://localhost:{port}/api/v1/auth/login` с неверным паролем.
    *   **Ожидаемый результат:** `401 Unauthorized` с `ProblemDetail`, у которого `type` URI заканчивается на `/auth/invalid-credentials`. Заголовок `WWW-Authenticate: Bearer ...` **присутствует**.