### PR TITLE
feat(scheduler): Add internal API for user ID processing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,16 @@ services:
     secrets:
       - postgres_user
       - postgres_password
+    command:
+      - "postgres"
+      - "-c"
+      - "log_statement=all"
+      - "-c"
+      - "log_destination=stderr"
+      - "-c"
+      - "log_duration=on"
+      - "-c"
+      - "log_min_duration_statement=0"
    
   kafka:
     image: bitnami/kafka:4.0.0 # Используем образ с поддержкой KRaft

--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/config/OpenApiConfig.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/config/OpenApiConfig.java
@@ -3,6 +3,7 @@ package com.example.tasktracker.backend.config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
 import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -20,6 +21,8 @@ import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import java.io.IOException;
 import java.io.InputStream;
 
+import static com.example.tasktracker.backend.security.filter.ApiKeyAuthenticationFilter.API_KEY_HEADER_NAME;
+
 @Configuration
 @Slf4j
 @OpenAPIDefinition(
@@ -36,6 +39,13 @@ import java.io.InputStream;
         type = SecuritySchemeType.HTTP,
         scheme = "bearer",
         bearerFormat = "JWT"
+)
+@SecurityScheme(
+        name = "apiKeyAuth",
+        type = SecuritySchemeType.APIKEY,
+        in = SecuritySchemeIn.HEADER,
+        paramName = API_KEY_HEADER_NAME,
+        description = "API-ключ для межсервисного взаимодействия (M2M)."
 )
 public class OpenApiConfig {
 

--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/internal/scheduler/config/SchedulerSupportApiProperties.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/internal/scheduler/config/SchedulerSupportApiProperties.java
@@ -1,0 +1,53 @@
+package com.example.tasktracker.backend.internal.scheduler.config;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * Конфигурационные свойства для API, поддерживающего сервис-планировщик.
+ */
+@Component
+@ConfigurationProperties(prefix = "app.internal-api.scheduler-support")
+@Validated
+@Getter
+@Setter
+public class SchedulerSupportApiProperties {
+
+    /**
+     * Конфигурация для эндпоинта, предоставляющего ID пользователей для обработки.
+     */
+    @Valid
+    private UserProcessingIdsEndpoint userProcessingIds = new UserProcessingIdsEndpoint();
+
+    @Getter
+    @Setter
+    public static class UserProcessingIdsEndpoint {
+        /**
+         * Размер страницы по умолчанию для пагинации ID пользователей.
+         */
+        @Positive(message = "{config.validation.positive}")
+        private int defaultPageSize = 1000;
+
+        /**
+         * Максимально допустимый размер страницы для пагинации ID пользователей.
+         */
+        @Positive(message = "{config.validation.positive}")
+        private int maxPageSize = 5000;
+
+        /**
+         * Кастомный метод валидации, проверяющий, что размер по умолчанию не превышает максимальный.
+         */
+        @AssertTrue(message = "{config.validation.scheduler.pageSize.defaultLessThanMax}")
+        @JsonIgnore
+        public boolean isDefaultSizeLessThanOrEqualToMaxSize() {
+            return defaultPageSize <= maxPageSize;
+        }
+    }
+}

--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/internal/scheduler/dto/PageInfo.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/internal/scheduler/dto/PageInfo.java
@@ -1,0 +1,21 @@
+package com.example.tasktracker.backend.internal.scheduler.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * DTO для метаданных пагинации, используемых в ответах API.
+ */
+@Schema(description = "Информация о пагинации")
+@Getter
+@AllArgsConstructor
+public class PageInfo {
+
+    @Schema(description = "Признак наличия следующей страницы данных.", example = "true")
+    private boolean hasNextPage;
+
+    @Schema(description = "Непрозрачный курсор для запроса следующей страницы. Null, если следующей страницы нет.",
+            nullable = true, example = "eyJsYXN0X2lkIjo1NDMyMX0=")
+    private String nextPageCursor;
+}

--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/internal/scheduler/dto/PaginatedUserIdsResponse.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/internal/scheduler/dto/PaginatedUserIdsResponse.java
@@ -1,0 +1,24 @@
+package com.example.tasktracker.backend.internal.scheduler.dto;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * DTO для ответа API, содержащего пагинированный список ID пользователей.
+ */
+@Schema(description = "Пагинированный ответ со списком ID пользователей")
+@Getter
+@AllArgsConstructor
+public class PaginatedUserIdsResponse {
+
+    @ArraySchema(schema = @Schema(description = "Список ID пользователей на текущей странице.",
+            type = "integer", format = "int64", example = "101"))
+    private List<Long> data;
+
+    @Schema(description = "Информация о пагинации для запроса следующей страницы.")
+    private PageInfo pageInfo;
+}

--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/internal/scheduler/service/SystemDataProvisionService.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/internal/scheduler/service/SystemDataProvisionService.java
@@ -1,0 +1,104 @@
+package com.example.tasktracker.backend.internal.scheduler.service;
+
+import com.example.tasktracker.backend.internal.scheduler.config.SchedulerSupportApiProperties;
+import com.example.tasktracker.backend.internal.scheduler.dto.PageInfo;
+import com.example.tasktracker.backend.internal.scheduler.dto.PaginatedUserIdsResponse;
+import com.example.tasktracker.backend.user.repository.UserQueryRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Slice;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.io.IOException;
+import java.util.Base64;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class SystemDataProvisionService {
+
+    private final UserQueryRepository userQueryRepository;
+    private final SchedulerSupportApiProperties properties;
+    private final ObjectMapper objectMapper;
+
+    private record UserKeysetCursor(long lastId) {
+    }
+
+    /**
+     * Получает пагинированный список ID пользователей для обработки.
+     *
+     * @param encodedCursor  Опциональный непрозрачный курсор (Base64) от предыдущего вызова.
+     * @param requestedLimit Опциональный запрошенный лимит записей.
+     * @return Объект с данными и информацией о следующей странице.
+     */
+    public PaginatedUserIdsResponse getUserIdsForProcessing(
+            @Nullable String encodedCursor,
+            @Nullable Integer requestedLimit
+    ) {
+        log.debug("Attempting to get user IDs for processing. Cursor is {}, requested limit is {}.",
+                encodedCursor != null ? "present" : "absent", requestedLimit);
+
+        final int finalLimit = Optional.ofNullable(requestedLimit)
+                .filter(limit -> limit > 0)
+                .map(limit -> Math.min(limit, properties.getUserProcessingIds().getMaxPageSize()))
+                .orElse(properties.getUserProcessingIds().getDefaultPageSize());
+
+        final long lastId = decodeCursor(encodedCursor);
+
+        log.debug("Executing user ID query with lastId: {} and effective limit: {}.", lastId, finalLimit);
+        Slice<Long> userIdsSlice = userQueryRepository.findUserIds(lastId, finalLimit);
+
+        final boolean hasNext = userIdsSlice.hasNext();
+        final String nextCursor = hasNext ? encodeCursor(userIdsSlice.getContent()) : null;
+        final PageInfo pageInfo = new PageInfo(hasNext, nextCursor);
+        final PaginatedUserIdsResponse response = new PaginatedUserIdsResponse(userIdsSlice.getContent(), pageInfo);
+
+        log.info("Successfully provisioned {} user IDs. HasNextPage: {}.",
+                response.getData().size(), response.getPageInfo().isHasNextPage());
+
+        return response;
+    }
+
+    private long decodeCursor(@Nullable String encodedCursor) {
+        if (!StringUtils.hasText(encodedCursor)) {
+            log.trace("Cursor is absent, starting from the beginning (lastId=0).");
+            return 0L;
+        }
+
+        try {
+            byte[] decodedBytes = Base64.getDecoder().decode(encodedCursor);
+            UserKeysetCursor cursor = objectMapper.readValue(decodedBytes, UserKeysetCursor.class);
+            return cursor.lastId();
+        } catch (IOException | IllegalArgumentException e) {
+            log.warn("Failed to decode or parse keyset cursor: '{}'. Defaulting to initial state.", encodedCursor, e);
+            return 0L;
+        }
+    }
+
+    @Nullable
+    private String encodeCursor(@NonNull List<Long> ids) {
+        if (ids.isEmpty()) {
+            log.trace("ID list is empty, no next cursor to encode.");
+            return null;
+        }
+
+        try {
+            Long lastIdInPage = ids.getLast();
+            UserKeysetCursor cursor = new UserKeysetCursor(lastIdInPage);
+            byte[] jsonBytes = objectMapper.writeValueAsBytes(cursor);
+            return Base64.getEncoder().encodeToString(jsonBytes);
+        } catch (JsonProcessingException e) {
+            log.error("CRITICAL: Failed to serialize keyset cursor. This indicates a programming error.", e);
+            throw new IllegalStateException("Failed to create a pagination cursor", e);
+        }
+    }
+}

--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/internal/scheduler/web/SchedulerSupportController.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/internal/scheduler/web/SchedulerSupportController.java
@@ -1,0 +1,58 @@
+package com.example.tasktracker.backend.internal.scheduler.web;
+
+import com.example.tasktracker.backend.internal.scheduler.dto.PaginatedUserIdsResponse;
+import com.example.tasktracker.backend.internal.scheduler.service.SystemDataProvisionService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/internal/scheduler-support")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "Internal API: Scheduler Support", description = "API для поддержки работы сервиса-планировщика")
+@SecurityRequirement(name = "apiKeyAuth")
+public class SchedulerSupportController {
+
+    private final SystemDataProvisionService provisionService;
+
+    @Operation(
+            summary = "Получить пагинированный список ID пользователей для обработки",
+            description = "Возвращает порцию ID пользователей с использованием keyset-пагинации на основе непрозрачного курсора."
+    )
+    @ApiResponse(
+            responseCode = "200", description = "Список ID успешно получен.",
+            content = @Content(mediaType = "application/json",
+            schema = @Schema(implementation = PaginatedUserIdsResponse.class)))
+    @ApiResponse(responseCode = "401", ref = "#/components/responses/UnauthorizedApiKey")
+    @ApiResponse(responseCode = "400", ref = "#/components/responses/BadRequestGeneral")
+    @GetMapping("/user-ids")
+    public ResponseEntity<PaginatedUserIdsResponse> getUserIdsForProcessing(
+            @Parameter(description = "Непрозрачный курсор для получения следующей страницы. " +
+                                     "Для первого запроса не передается.")
+            @RequestParam(required = false) String cursor,
+
+            @Parameter(description = "Максимальное количество ID в ответе.")
+            @Positive(message = "{config.validation.positive}")
+            @RequestParam(required = false) Integer limit
+    ) {
+        log.info("Processing request for user IDs. Cursor is {}, requested limit is {}.",
+                cursor != null ? "present" : "absent", limit);
+        PaginatedUserIdsResponse response = provisionService.getUserIdsForProcessing(cursor, limit);
+        log.info("Successfully returned {} user IDs. HasNextPage: {}.",
+                response.getData().size(), response.getPageInfo().isHasNextPage());
+        return ResponseEntity.ok(response);
+    }
+}

--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/user/repository/JdbcUserQueryRepository.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/user/repository/JdbcUserQueryRepository.java
@@ -1,0 +1,49 @@
+package com.example.tasktracker.backend.user.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+/**
+ * Реализация {@link UserQueryRepository} с использованием JdbcTemplate для оптимального выполнения запросов.
+ */
+@Repository
+@RequiredArgsConstructor
+public class JdbcUserQueryRepository implements UserQueryRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Slice<Long> findUserIds(long lastProcessedId, int limit) {
+        final int queryLimit = limit + 1;
+
+        final String sql = """
+                SELECT id
+                FROM users
+                WHERE id > ?
+                ORDER BY id ASC
+                LIMIT ?
+                """;
+
+        List<Long> ids = jdbcTemplate.query(
+                sql,
+                (rs, rowNum) -> rs.getLong("id"),
+                lastProcessedId,
+                queryLimit
+        );
+
+        boolean hasNext = ids.size() > limit;
+        List<Long> content = hasNext ? ids.subList(0, limit) : ids;
+
+        // Slice не имеет информации об общем количестве страниц, поэтому номер страницы (0) здесь условный.
+        return new SliceImpl<>(content, PageRequest.of(0, limit), hasNext);
+    }
+}

--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/user/repository/UserQueryRepository.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/user/repository/UserQueryRepository.java
@@ -1,0 +1,21 @@
+package com.example.tasktracker.backend.user.repository;
+
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Репозиторий для выполнения сложных или специфичных "читающих" запросов,
+ * связанных с пользователями, которые не являются частью стандартного CRUD.
+ */
+@Repository
+public interface UserQueryRepository {
+
+    /**
+     * Находит порцию ID пользователей для обработки, используя keyset-пагинацию.
+     *
+     * @param lastProcessedId ID последнего обработанного пользователя. Запрос выберет пользователей с ID > этого значения.
+     * @param limit           Максимальное количество ID для возврата.
+     * @return Слайс (Slice) с ID пользователей.
+     */
+    Slice<Long> findUserIds(long lastProcessedId, int limit);
+}

--- a/task-tracker-backend/src/main/resources/application.yml
+++ b/task-tracker-backend/src/main/resources/application.yml
@@ -16,7 +16,7 @@ spring:
     enabled: true
     change-log: classpath:/db/changelog/db.changelog-master.yaml
   messages:
-    basename: i18n/common/messages,i18n/security/messages, i18n/user/messages, i18n/task/messages
+    basename: i18n/config/validation,i18n/common/messages,i18n/security/messages, i18n/user/messages, i18n/task/messages
     encoding: UTF-8
     fallback-to-system-locale: false
   jackson:
@@ -105,3 +105,8 @@ app:
   security:
     jwt:
       expiration-ms: 3600000 # 1 час
+  internal-api:
+    scheduler-support:
+      user-processing-ids:
+        default-page-size: 1000
+        max-page-size: 5000

--- a/task-tracker-backend/src/main/resources/i18n/common/messages.properties
+++ b/task-tracker-backend/src/main/resources/i18n/common/messages.properties
@@ -1,5 +1,5 @@
 # =============================================================
-# Task Tracker Application - Common API Error Messages
+    # Task Tracker Application - Common API Error Messages
 # =============================================================
 
 # Ключ "request.body.conversionError" используется в GlobalExceptionHandler
@@ -29,3 +29,7 @@ problemDetail.request.parameter.typeMismatch.detail=Parameter {0} could not be c
 # --- Ключи для ResourceConflictException (409 Conflict) ---
 problemDetail.resource.conflict.title=Resource Conflict
 problemDetail.resource.conflict.detail=The resource was modified by another request. Please fetch the latest version and try again.
+
+# --- Ключи для HandlerMethodValidationException (400 Bad Request - ошибки валидации @RequestParam, @PathVariable) ---
+problemDetail.validation.methodParameterInvalid.title=Invalid Request Parameter
+problemDetail.validation.methodParameterInvalid.detail=Validation failed for {0} request parameter(s).

--- a/task-tracker-backend/src/main/resources/i18n/config/validation.properties
+++ b/task-tracker-backend/src/main/resources/i18n/config/validation.properties
@@ -1,0 +1,18 @@
+# ======================================================================
+# Task Tracker Application - Configuration & Startup Validation Messages
+# ======================================================================
+
+# --- General Config Validation ---
+config.validation.positive=Configuration property must be a positive number.
+
+# --- Scheduler Support API Config Validation ---
+config.validation.scheduler.pageSize.defaultLessThanMax=Default page size cannot be greater than the maximum page size.
+
+# --- JWT ConfigurationProperties Validation (@Validated on JwtProperties) ---
+security.jwt.secretKey.notBlank=JWT secret key must not be blank and must be provided in Base64 format.
+security.jwt.expirationMs.positive=JWT expiration time in milliseconds must be a positive number.
+security.jwt.claims.emailKey.notBlank=Configuration for JWT email claim key must not be blank.
+security.jwt.claims.authoritiesKey.notBlank=Configuration for JWT authorities claim key must not be blank.
+
+# --- API Key Configuration Validation ---
+security.apiKey.keysToServices.notEmpty=At least one API key-to-service mapping must be configured.

--- a/task-tracker-backend/src/main/resources/i18n/security/messages.properties
+++ b/task-tracker-backend/src/main/resources/i18n/security/messages.properties
@@ -3,13 +3,6 @@
 # (Covers JWT, Auth, Security-related Problem Details)
 # =======================================================
 
-# --- Validation Messages for Security Properties ---
-security.jwt.secretKey.notBlank=JWT secret key must not be blank and must be provided in Base64 format.
-security.jwt.expirationMs.positive=JWT expiration time in milliseconds must be a positive number.
-security.jwt.claims.emailKey.notBlank=Configuration for JWT email claim key must not be blank.
-security.jwt.claims.authoritiesKey.notBlank=Configuration for JWT authorities claim key must not be blank.
-security.apiKey.keysToServices.notEmpty=At least one API key-to-service mapping must be configured.
-
 # --- Problem Details: JWT Errors (BadJwtException) ---
 problemDetail.jwt.expired.title=Expired Token
 problemDetail.jwt.expired.detail=The provided authentication token has expired. Please log in again.

--- a/task-tracker-backend/src/main/resources/openapi-components.yml
+++ b/task-tracker-backend/src/main/resources/openapi-components.yml
@@ -281,6 +281,19 @@ components:
             detail: "The email or password provided is incorrect."
             instance: "/api/v1/auth/login"
 
+    UnauthorizedApiKey:
+      description: "API-ключ отсутствует, невалиден или не имеет прав на доступ к этому ресурсу."
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/BaseProblemDetail'
+          example:
+            type: "https://task-tracker.example.com/probs/auth/invalid-api-key"
+            title: "Invalid API Key"
+            status: 401
+            detail: "The provided X-API-Key is missing or invalid."
+            instance: "/api/v1/internal/scheduler-support/user-ids"
+
     # ---------------------------------------------------------
     # 404 - NOT FOUND
     # ---------------------------------------------------------

--- a/task-tracker-backend/src/test/java/com/example/tasktracker/backend/internal/scheduler/service/SystemDataProvisionServiceTest.java
+++ b/task-tracker-backend/src/test/java/com/example/tasktracker/backend/internal/scheduler/service/SystemDataProvisionServiceTest.java
@@ -1,0 +1,196 @@
+package com.example.tasktracker.backend.internal.scheduler.service;
+
+import com.example.tasktracker.backend.internal.scheduler.config.SchedulerSupportApiProperties;
+import com.example.tasktracker.backend.internal.scheduler.dto.PaginatedUserIdsResponse;
+import com.example.tasktracker.backend.user.repository.UserQueryRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+
+import java.util.Base64;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Unit-тесты для SystemDataProvisionService")
+class SystemDataProvisionServiceTest {
+
+    @Mock private UserQueryRepository mockUserQueryRepository;
+    @Mock private SchedulerSupportApiProperties mockProperties;
+    private final ObjectMapper realObjectMapper = new ObjectMapper();
+
+    private SystemDataProvisionService service;
+
+    private static final int DEFAULT_PAGE_SIZE = 1000;
+    private static final int MAX_PAGE_SIZE = 5000;
+
+    @BeforeEach
+    void setUp() {
+        service = new SystemDataProvisionService(mockUserQueryRepository, mockProperties, realObjectMapper);
+
+        SchedulerSupportApiProperties.UserProcessingIdsEndpoint endpointProps = new SchedulerSupportApiProperties.UserProcessingIdsEndpoint();
+        endpointProps.setDefaultPageSize(DEFAULT_PAGE_SIZE);
+        endpointProps.setMaxPageSize(MAX_PAGE_SIZE);
+        when(mockProperties.getUserProcessingIds()).thenReturn(endpointProps);
+
+        // Общая настройка для всех тестов, где репозиторий может быть вызван
+        when(mockUserQueryRepository.findUserIds(anyLong(), anyInt())).thenReturn(new SliceImpl<>(List.of()));
+    }
+
+    @Nested
+    @DisplayName("Обработка лимитов")
+    class LimitHandlingTests {
+
+        @Test
+        @DisplayName("Когда лимит не передан (null) -> должен использоваться defaultPageSize")
+        void getUserIdsForProcessing_whenLimitIsNull_shouldUseDefaultPageSize() {
+            // Act
+            service.getUserIdsForProcessing(null, null);
+
+            // Assert
+            verify(mockUserQueryRepository).findUserIds(0L, DEFAULT_PAGE_SIZE);
+        }
+
+        @Test
+        @DisplayName("Когда запрошенный лимит в пределах нормы -> должен использоваться запрошенный лимит")
+        void getUserIdsForProcessing_whenRequestedLimitIsValid_shouldUseRequestedLimit() {
+            // Arrange
+            int requestedLimit = 50;
+
+            // Act
+            service.getUserIdsForProcessing(null, requestedLimit);
+
+            // Assert
+            verify(mockUserQueryRepository).findUserIds(0L, requestedLimit);
+        }
+
+        @Test
+        @DisplayName("Когда запрошенный лимит превышает максимальный -> должен использоваться maxPageSize")
+        void getUserIdsForProcessing_whenRequestedLimitExceedsMax_shouldUseMaxPageSize() {
+            // Arrange
+            int requestedLimit = 9999;
+
+            // Act
+            service.getUserIdsForProcessing(null, requestedLimit);
+
+            // Assert
+            verify(mockUserQueryRepository).findUserIds(0L, MAX_PAGE_SIZE);
+        }
+    }
+
+    @Nested
+    @DisplayName("Обработка курсора и пагинации")
+    class CursorAndPaginationTests {
+
+        @Test
+        @DisplayName("Первый запрос (курсор null) -> должен вернуть первую страницу и курсор на следующую")
+        void getUserIdsForProcessing_whenCursorIsNull_shouldReturnFirstPageAndNextCursor() {
+            // Arrange
+            List<Long> ids = List.of(1L, 2L, 3L);
+            Slice<Long> mockSlice = new SliceImpl<>(ids, PageRequest.of(0, 3), true); // hasNext = true
+            when(mockUserQueryRepository.findUserIds(0L, 3)).thenReturn(mockSlice);
+
+            // Act
+            PaginatedUserIdsResponse response = service.getUserIdsForProcessing(null, 3);
+
+            // Assert
+            assertThat(response.getData()).isEqualTo(ids);
+            assertThat(response.getPageInfo().isHasNextPage()).isTrue();
+
+            String expectedCursorJson = "{\"lastId\":3}";
+            String expectedEncodedCursor = Base64.getEncoder().encodeToString(expectedCursorJson.getBytes());
+            assertThat(response.getPageInfo().getNextPageCursor()).isEqualTo(expectedEncodedCursor);
+        }
+
+        @Test
+        @DisplayName("Запрос с курсором для промежуточной страницы -> должен вернуть данные и новый курсор")
+        void getUserIdsForProcessing_whenCursorIsValidForIntermediatePage_shouldReturnDataAndNextCursor() {
+            // Arrange
+            String cursorJson = "{\"lastId\":10}";
+            String encodedCursor = Base64.getEncoder().encodeToString(cursorJson.getBytes());
+            List<Long> ids = List.of(11L, 12L);
+            Slice<Long> mockSlice = new SliceImpl<>(ids, PageRequest.of(0, 2), true);
+            when(mockUserQueryRepository.findUserIds(10L, 2)).thenReturn(mockSlice);
+
+            // Act
+            PaginatedUserIdsResponse response = service.getUserIdsForProcessing(encodedCursor, 2);
+
+            // Assert
+            assertThat(response.getData()).isEqualTo(ids);
+            assertThat(response.getPageInfo().isHasNextPage()).isTrue();
+            String expectedNextCursorJson = "{\"lastId\":12}";
+            String expectedEncodedNextCursor = Base64.getEncoder().encodeToString(expectedNextCursorJson.getBytes());
+            assertThat(response.getPageInfo().getNextPageCursor()).isEqualTo(expectedEncodedNextCursor);
+        }
+
+        @Test
+        @DisplayName("Запрос с курсором для последней страницы -> должен вернуть данные, но без нового курсора")
+        void getUserIdsForProcessing_whenCursorIsValidForLastPage_shouldReturnDataAndNoNextCursor() {
+            // Arrange
+            String cursorJson = "{\"lastId\":10}";
+            String encodedCursor = Base64.getEncoder().encodeToString(cursorJson.getBytes());
+            List<Long> ids = List.of(11L, 12L);
+            Slice<Long> mockSlice = new SliceImpl<>(ids, PageRequest.of(0, 2), false); // hasNext = false
+            when(mockUserQueryRepository.findUserIds(10L, 2)).thenReturn(mockSlice);
+
+            // Act
+            PaginatedUserIdsResponse response = service.getUserIdsForProcessing(encodedCursor, 2);
+
+            // Assert
+            assertThat(response.getData()).isEqualTo(ids);
+            assertThat(response.getPageInfo().isHasNextPage()).isFalse();
+            assertThat(response.getPageInfo().getNextPageCursor()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("Обработка граничных и ошибочных случаев")
+    class EdgeAndErrorCasesTests {
+
+        @Test
+        @DisplayName("Невалидный (битый) курсор -> должен обработать ошибку и запросить первую страницу")
+        void getUserIdsForProcessing_whenCursorIsInvalid_shouldGracefullyHandleAndRequestFirstPage() {
+            // Arrange
+            String invalidCursor = "this-is-not-base64-or-json";
+            List<Long> firstPageIds = List.of(1L, 2L);
+            Slice<Long> mockSlice = new SliceImpl<>(firstPageIds, PageRequest.of(0, 2), false);
+            when(mockUserQueryRepository.findUserIds(0L, 2)).thenReturn(mockSlice);
+
+            // Act
+            PaginatedUserIdsResponse response = service.getUserIdsForProcessing(invalidCursor, 2);
+
+            // Assert
+            verify(mockUserQueryRepository).findUserIds(0L, 2);
+            assertThat(response.getData()).isEqualTo(firstPageIds);
+        }
+
+        @Test
+        @DisplayName("Репозиторий возвращает пустой слайс -> ответ должен быть пустым без курсора")
+        void getUserIdsForProcessing_whenRepositoryReturnsEmptySlice_shouldReturnEmptyResponseWithNoCursor() {
+            // Arrange
+            Slice<Long> emptySlice = new SliceImpl<>(List.of());
+            when(mockUserQueryRepository.findUserIds(anyLong(), anyInt())).thenReturn(emptySlice);
+
+            // Act
+            PaginatedUserIdsResponse response = service.getUserIdsForProcessing(null, 10);
+
+            // Assert
+            assertThat(response.getData()).isEmpty();
+            assertThat(response.getPageInfo().isHasNextPage()).isFalse();
+            assertThat(response.getPageInfo().getNextPageCursor()).isNull();
+        }
+    }
+}

--- a/task-tracker-backend/src/test/java/com/example/tasktracker/backend/internal/scheduler/web/SchedulerSupportControllerIT.java
+++ b/task-tracker-backend/src/test/java/com/example/tasktracker/backend/internal/scheduler/web/SchedulerSupportControllerIT.java
@@ -1,0 +1,209 @@
+package com.example.tasktracker.backend.internal.scheduler.web;
+
+import com.example.tasktracker.backend.internal.scheduler.dto.PaginatedUserIdsResponse;
+import com.example.tasktracker.backend.security.apikey.ApiKeyProperties;
+import com.example.tasktracker.backend.security.filter.ApiKeyAuthenticationFilter;
+import com.example.tasktracker.backend.user.entity.User;
+import com.example.tasktracker.backend.user.repository.UserRepository;
+import com.example.tasktracker.backend.web.ApiConstants;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.http.*;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.util.UriComponentsBuilder;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.net.URI;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Testcontainers
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("ci")
+@DisplayName("Интеграционные тесты для SchedulerSupportController")
+class SchedulerSupportControllerIT {
+
+    @Container
+    @ServiceConnection
+    static final PostgreSQLContainer<?> postgresContainer =
+            new PostgreSQLContainer<>("postgres:17.4-alpine");
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate testRestTemplate;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ApiKeyProperties apiKeyProperties;
+
+    private String validApiKey;
+
+    private String baseInternalUrl;
+
+    @BeforeEach
+    void setUp() {
+        userRepository.deleteAllInBatch();
+        baseInternalUrl = "http://localhost:" + port + "/api/v1/internal/scheduler-support";
+
+        validApiKey = apiKeyProperties.getKeysToServices().keySet().stream()
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("No API keys configured in application-ci.yml for testing"));
+    }
+
+    @AfterEach
+    void tearDown() {
+        userRepository.deleteAllInBatch();
+    }
+
+    private HttpEntity<Void> createHttpEntityWithApiKey(String apiKey) {
+        HttpHeaders headers = new HttpHeaders();
+        if (apiKey != null) {
+            headers.set(ApiKeyAuthenticationFilter.API_KEY_HEADER_NAME, apiKey);
+        }
+        return new HttpEntity<>(headers);
+    }
+
+    @Test
+    @DisplayName("GET /user-ids: Валидный API-ключ -> должен вернуть 200 OK")
+    void getUserIds_withValidApiKey_shouldReturn200() {
+        // Arrange
+        HttpEntity<Void> entity = createHttpEntityWithApiKey(validApiKey);
+        URI uri = UriComponentsBuilder.fromUriString(baseInternalUrl + "/user-ids").build().toUri();
+
+        // Act
+        ResponseEntity<PaginatedUserIdsResponse> response =
+                testRestTemplate.exchange(uri, HttpMethod.GET, entity, PaginatedUserIdsResponse.class);
+
+        // Assert
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    @DisplayName("GET /user-ids: Невалидный API-ключ -> должен вернуть 401 Unauthorized")
+    void getUserIds_withInvalidApiKey_shouldReturn401() {
+        // Arrange
+        HttpEntity<Void> entity = createHttpEntityWithApiKey("invalid-key-123");
+        URI uri = UriComponentsBuilder.fromUriString(baseInternalUrl + "/user-ids").build().toUri();
+
+        // Act
+        ResponseEntity<ProblemDetail> response =
+                testRestTemplate.exchange(uri, HttpMethod.GET, entity, ProblemDetail.class);
+
+        // Assert
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getType()).hasToString(ApiConstants.PROBLEM_TYPE_BASE_URI + "auth/invalid-api-key");
+    }
+
+    @Test
+    @DisplayName("GET /user-ids: Отсутствует API-ключ -> должен вернуть 401 Unauthorized")
+    void getUserIds_withoutApiKey_shouldReturn401() {
+        // Arrange
+        HttpEntity<Void> entity = createHttpEntityWithApiKey(null);
+        URI uri = UriComponentsBuilder.fromUriString(baseInternalUrl + "/user-ids").build().toUri();
+
+        // Act
+        ResponseEntity<ProblemDetail> response =
+                testRestTemplate.exchange(uri, HttpMethod.GET, entity, ProblemDetail.class);
+
+        // Assert
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    @DisplayName("GET /user-ids: Невалидный limit -> должен вернуть 400 Bad Request")
+    void getUserIds_withInvalidLimit_shouldReturn400() {
+        // Arrange
+        HttpEntity<Void> entity = createHttpEntityWithApiKey(validApiKey);
+        URI uri = UriComponentsBuilder.fromUriString(baseInternalUrl + "/user-ids")
+                .queryParam("limit", 0) // Невалидный limit
+                .build().toUri();
+
+        // Act
+        ResponseEntity<ProblemDetail> response =
+                testRestTemplate.exchange(uri, HttpMethod.GET, entity, ProblemDetail.class);
+
+        // Assert
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getType()).hasToString(ApiConstants.PROBLEM_TYPE_BASE_URI + "validation/constraint-violation");
+    }
+
+    @Test
+    @DisplayName("GET /user-ids: Полный цикл пагинации -> должен корректно вернуть все страницы")
+    void getUserIds_fullPaginationCycle_shouldReturnAllPagesCorrectly() {
+        // Arrange
+        // Создаем 5 пользователей
+        IntStream.rangeClosed(1, 5).forEach(i -> {
+            User user = new User();
+            user.setEmail("user" + i + "@example.com");
+            user.setPassword("password");
+            userRepository.save(user);
+        });
+
+        HttpEntity<Void> entity = createHttpEntityWithApiKey(validApiKey);
+
+        // --- Страница 1 ---
+        URI uriPage1 = UriComponentsBuilder.fromUriString(baseInternalUrl + "/user-ids")
+                .queryParam("limit", 2)
+                .build().toUri();
+
+        ResponseEntity<PaginatedUserIdsResponse> response1 =
+                testRestTemplate.exchange(uriPage1, HttpMethod.GET, entity, PaginatedUserIdsResponse.class);
+
+        assertThat(response1.getStatusCode()).isEqualTo(HttpStatus.OK);
+        PaginatedUserIdsResponse body1 = response1.getBody();
+        assertThat(body1).isNotNull();
+        assertThat(body1.getData()).hasSize(2); // ID могут быть не 1 и 2 из-за sequence
+        assertThat(body1.getPageInfo().isHasNextPage()).isTrue();
+        assertThat(body1.getPageInfo().getNextPageCursor()).isNotBlank();
+        String cursor2 = body1.getPageInfo().getNextPageCursor();
+
+        // --- Страница 2 ---
+        URI uriPage2 = UriComponentsBuilder.fromUriString(baseInternalUrl + "/user-ids")
+                .queryParam("limit", 2)
+                .queryParam("cursor", cursor2)
+                .build().toUri();
+
+        ResponseEntity<PaginatedUserIdsResponse> response2 =
+                testRestTemplate.exchange(uriPage2, HttpMethod.GET, entity, PaginatedUserIdsResponse.class);
+
+        assertThat(response2.getStatusCode()).isEqualTo(HttpStatus.OK);
+        PaginatedUserIdsResponse body2 = response2.getBody();
+        assertThat(body2).isNotNull();
+        assertThat(body2.getData()).hasSize(2);
+        assertThat(body2.getPageInfo().isHasNextPage()).isTrue();
+        assertThat(body2.getPageInfo().getNextPageCursor()).isNotBlank();
+        String cursor3 = body2.getPageInfo().getNextPageCursor();
+
+        // --- Страница 3 (последняя) ---
+        URI uriPage3 = UriComponentsBuilder.fromUriString(baseInternalUrl + "/user-ids")
+                .queryParam("limit", 2)
+                .queryParam("cursor", cursor3)
+                .build().toUri();
+
+        ResponseEntity<PaginatedUserIdsResponse> response3 =
+                testRestTemplate.exchange(uriPage3, HttpMethod.GET, entity, PaginatedUserIdsResponse.class);
+
+        assertThat(response3.getStatusCode()).isEqualTo(HttpStatus.OK);
+        PaginatedUserIdsResponse body3 = response3.getBody();
+        assertThat(body3).isNotNull();
+        assertThat(body3.getData()).hasSize(1);
+        assertThat(body3.getPageInfo().isHasNextPage()).isFalse();
+        assertThat(body3.getPageInfo().getNextPageCursor()).isNull();
+    }
+}


### PR DESCRIPTION
### **Описание (Description)**

Этот Pull Request решает задачу **`API-SCHED-01.2`** и связанные с ней доработки. Он реализует в `task-tracker-backend` новый, высокопроизводительный и гибкий внутренний API (`GET /api/v1/internal/scheduler-support/user-ids`), предназначенный для предоставления ID пользователей сервису-планировщику.

Главное нововведение — **внедрение keyset-пагинации на основе непрозрачного курсора**. Этот подход обеспечивает слабую связанность между сервисами: бэкенд может в будущем изменять логику пагинации (например, поля сортировки), не ломая при этом контракт с клиентом (планировщиком).

**Ключевые изменения и улучшения:**

*   **Доменная организация кода:** Вся логика, связанная с поддержкой планировщика, инкапсулирована в новой структуре пакетов `.../internal/scheduler/`, что соответствует нашему доменному подходу (ADR-0007).
*   **Оптимизация на уровне БД:** Реализован специализированный `UserQueryRepository`, использующий `Slice<Long>` для предотвращения лишних `COUNT`-запросов к базе данных.
*   **Type-Safe и валидируемая конфигурация:** Создан `@ConfigurationProperties` класс для управления параметрами пагинации, с надежной валидацией при старте приложения, включая проверку логической консистентности `defaultPageSize` и `maxPageSize`.
*   **Надежная обработка ошибок валидации:** `GlobalExceptionHandler` был доработан для корректной обработки `HandlerMethodValidationException`, возникающей при валидации `@RequestParam`. Теперь все ошибки валидации входных данных возвращают консистентный, кастомизированный `ProblemDetail`.

### **Реализованный функционал (Implemented Functionality)**

*   **Новый эндпоинт:** `GET /api/v1/internal/scheduler-support/user-ids`
    *   **Параметры:** `cursor` (string, optional), `limit` (integer, optional).
    *   **Ответ:** JSON-объект, содержащий `data` (список ID) и `page_info` (с полями `has_next_page` и `next_page_cursor`).
*   **Новые компоненты:**
    *   `SchedulerSupportController`, `SystemDataProvisionService`, `SchedulerSupportApiProperties`.
    *   `UserQueryRepository` и его JDBC-реализация.
    *   DTO: `PaginatedUserIdsResponse`, `PageInfo`.
*   **Обновленная конфигурация:**
    *   Добавлены `app.internal-api.scheduler-support.*` свойства в `application.yml`.
    *   Добавлены ключи для сообщений об ошибках валидации в `messages.properties`.
    *   Обновлена OpenAPI документация.

### **Критерии Приемки (Acceptance Criteria Checklist)**

*   [x] **AC1: Эндпоинт и Контракт:** Эндпоинт реализован и возвращает ответ в согласованной структуре с `data` и `page_info`.
*   [x] **AC2: Логика Непрозрачного Курсора:** Сервис корректно кодирует и декодирует курсор, основанный на `last_id`.
*   [x] **AC3: Логика Keyset-пагинации:** Используется `Slice<Long>`, `hasNextPage` определяется корректно.
*   [x] **AC4: Безопасность:** Эндпоинт защищен механизмом API-ключа (проверяется в интеграционных тестах).
*   [x] **AC5: Тестирование:**
    *   [x] Написаны юнит-тесты для `SystemDataProvisionService`.
    *   [x] Написаны интеграционные тесты для `SchedulerSupportController`, покрывающие безопасность, валидацию и пагинацию.
*   [x] **AC6: Документация:** Эндпоинт задокументирован в OpenAPI.

### **Соответствие Definition of Done (DoD Checklist)**

*   [x] Код написан и соответствует стандартам проекта.
*   [x] Javadoc написан/обновлен для всех новых и измененных компонентов.
*   [x] Реализованы все AC для задачи `API-SCHED-01.2`.
*   [x] Юнит-тесты написаны/обновлены.
*   [x] Интеграционные тесты написаны/обновлены.
*   [x] Покрытие кода тестами (JaCoCo) проверено.
*   [x] Код успешно прошел Code Review.
*   [x] CI/CD пайплайн (Jenkins) успешно проходит для этого кода.
*   [x] Соответствующая документация (ADR) актуальна.
*   [x] Новая задача по рефакторингу ошибок валидации занесена в бэклог (`REFACTOR-API-01`).

### **Как тестировать (How to Test Manually)**

1.  **Тест 1 (Первая страница):** Отправить `GET`-запрос на `http://localhost:{port}/api/v1/internal/scheduler-support/user-ids?limit=2` с валидным заголовком `X-API-Key`.
    *   **Ожидаемый результат:** `200 OK` с телом, содержащим `data` (первые 2 ID), `has_next_page: true` и непустой `next_page_cursor`.
2.  **Тест 2 (Следующая страница):** Взять `next_page_cursor` из ответа Теста 1 и отправить `GET`-запрос на `.../user-ids?limit=2&cursor={cursor_from_test_1}`.
    *   **Ожидаемый результат:** `200 OK` со следующей порцией данных.
3.  **Тест 3 (Невалидный `limit`):** Отправить `GET`-запрос на `.../user-ids?limit=0`.
    *   **Ожидаемый результат:** `400 Bad Request` с `ProblemDetail`, у которого `type` URI заканчивается на `/validation/constraint-violation`.