### PR TITLE
feat(backend-internal): Implement and test task report API for scheduler

### DIFF
--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/internal/scheduler/config/SchedulerSupportApiProperties.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/internal/scheduler/config/SchedulerSupportApiProperties.java
@@ -26,6 +26,12 @@ public class SchedulerSupportApiProperties {
     @Valid
     private UserProcessingIdsEndpoint userProcessingIds = new UserProcessingIdsEndpoint();
 
+    /**
+     * Конфигурация для эндпоинта, предоставляющего отчеты по задачам.
+     */
+    @Valid
+    private UserTaskReportEndpoint userTaskReport = new UserTaskReportEndpoint();
+
     @Getter
     @Setter
     public static class UserProcessingIdsEndpoint {
@@ -49,5 +55,21 @@ public class SchedulerSupportApiProperties {
         public boolean isDefaultSizeLessThanOrEqualToMaxSize() {
             return defaultPageSize <= maxPageSize;
         }
+    }
+
+    @Getter
+    @Setter
+    public static class UserTaskReportEndpoint {
+        /**
+         * Максимальная длительность интервала отчета в днях.
+         */
+        @Positive(message = "{config.validation.positive}")
+        private int maxIntervalDays = 3;
+
+        /**
+         * Максимальный возраст отчета в днях (насколько "в прошлое" можно запрашивать отчет).
+         */
+        @Positive(message = "{config.validation.positive}")
+        private int maxAgeDays = 30;
     }
 }

--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/internal/scheduler/dto/PageInfo.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/internal/scheduler/dto/PageInfo.java
@@ -1,21 +1,22 @@
 package com.example.tasktracker.backend.internal.scheduler.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
+import lombok.*;
 
 /**
  * DTO для метаданных пагинации, используемых в ответах API.
  */
 @Schema(description = "Информация о пагинации")
 @Getter
-@AllArgsConstructor
+@RequiredArgsConstructor
+@ToString
+@EqualsAndHashCode
 public class PageInfo {
 
     @Schema(description = "Признак наличия следующей страницы данных.", example = "true")
-    private boolean hasNextPage;
+    private final boolean hasNextPage;
 
     @Schema(description = "Непрозрачный курсор для запроса следующей страницы. Null, если следующей страницы нет.",
             nullable = true, example = "eyJsYXN0X2lkIjo1NDMyMX0=")
-    private String nextPageCursor;
+    private final String nextPageCursor;
 }

--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/internal/scheduler/dto/PaginatedUserIdsResponse.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/internal/scheduler/dto/PaginatedUserIdsResponse.java
@@ -2,8 +2,10 @@ package com.example.tasktracker.backend.internal.scheduler.dto;
 
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 
 import java.util.List;
 
@@ -12,13 +14,15 @@ import java.util.List;
  */
 @Schema(description = "Пагинированный ответ со списком ID пользователей")
 @Getter
-@AllArgsConstructor
+@RequiredArgsConstructor
+@ToString
+@EqualsAndHashCode
 public class PaginatedUserIdsResponse {
 
     @ArraySchema(schema = @Schema(description = "Список ID пользователей на текущей странице.",
             type = "integer", format = "int64", example = "101"))
-    private List<Long> data;
+    private final List<Long> data;
 
     @Schema(description = "Информация о пагинации для запроса следующей страницы.")
-    private PageInfo pageInfo;
+    private final PageInfo pageInfo;
 }

--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/internal/scheduler/dto/TaskInfo.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/internal/scheduler/dto/TaskInfo.java
@@ -1,0 +1,25 @@
+package com.example.tasktracker.backend.internal.scheduler.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+/**
+ * Упрощенное DTO для представления информации о задаче в отчетах планировщика.
+ * Является неизменяемым (immutable).
+ */
+@Schema(description = "Упрощенная информация о задаче для отчетов")
+@Getter
+@RequiredArgsConstructor
+@ToString
+@EqualsAndHashCode
+public final class TaskInfo {
+
+    @Schema(description = "ID задачи", example = "101", requiredMode = Schema.RequiredMode.REQUIRED)
+    private final Long id;
+
+    @Schema(description = "Заголовок задачи", example = "Завершить отчет по Q2", requiredMode = Schema.RequiredMode.REQUIRED)
+    private final String title;
+}

--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/internal/scheduler/dto/UserTaskReport.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/internal/scheduler/dto/UserTaskReport.java
@@ -1,0 +1,39 @@
+package com.example.tasktracker.backend.internal.scheduler.dto;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * DTO, представляющий отчет по задачам для одного пользователя,
+ * сгенерированный для сервиса-планировщика.
+ */
+@Schema(description = "Отчет по задачам для одного пользователя")
+@Getter
+@ToString
+@EqualsAndHashCode
+@RequiredArgsConstructor
+public final class UserTaskReport {
+
+    @Schema(description = "ID пользователя", example = "42", requiredMode = Schema.RequiredMode.REQUIRED)
+    private final Long userId;
+
+    @Schema(description = "Email пользователя", example = "user@example.com", requiredMode = Schema.RequiredMode.REQUIRED)
+    private final String email;
+
+    @ArraySchema(schema = @Schema(implementation = TaskInfo.class,
+            description = "Список недавно выполненных задач (отсортированы по времени завершения)."))
+    private final List<TaskInfo> tasksCompleted = new ArrayList<>();
+
+    @ArraySchema(schema = @Schema(implementation = TaskInfo.class,
+            description = "Список самых старых невыполненных задач (не более 5, отсортированы по времени создания)."))
+    private final List<TaskInfo> tasksPending = new ArrayList<>();
+
+
+}

--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/internal/scheduler/dto/UserTaskReportRequest.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/internal/scheduler/dto/UserTaskReportRequest.java
@@ -1,0 +1,42 @@
+// file: src/main/java/com/example/tasktracker/backend/internal/scheduler/dto/UserTaskReportRequest.java
+package com.example.tasktracker.backend.internal.scheduler.dto;
+
+import com.example.tasktracker.backend.internal.scheduler.validation.ValidReportInterval;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * DTO для запроса на формирование отчетов по задачам для списка пользователей
+ * за определенный временной интервал.
+ */
+@Schema(description = "Запрос на формирование отчетов по задачам")
+@Getter
+@AllArgsConstructor
+@ToString
+@EqualsAndHashCode
+@ValidReportInterval
+public final class UserTaskReportRequest {
+
+    @ArraySchema(schema = @Schema(description = "Список ID пользователей для обработки.",
+            type = "integer", format = "int64", example = "101"))
+    @NotNull(message = "User ID list cannot be null.")
+    private final List<Long> userIds;
+
+    @Schema(description = "Начало временного интервала (включительно) для отчета.",
+            example = "2025-06-21T00:00:00Z", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotNull(message = "Report start time ('from') cannot be null.")
+    private final Instant from;
+
+    @Schema(description = "Конец временного интервала (исключительно) для отчета.",
+            example = "2025-06-22T00:00:00Z", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotNull(message = "Report end time ('to') cannot be null.")
+    private final Instant to;
+}

--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/internal/scheduler/validation/ValidReportInterval.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/internal/scheduler/validation/ValidReportInterval.java
@@ -1,0 +1,15 @@
+package com.example.tasktracker.backend.internal.scheduler.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = ValidReportIntervalValidator.class)
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidReportInterval {
+    String message() default "{internal.report.validation.invalidInterval.default}";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/internal/scheduler/validation/ValidReportIntervalValidator.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/internal/scheduler/validation/ValidReportIntervalValidator.java
@@ -1,0 +1,65 @@
+// file: src/main/java/com/example/tasktracker/backend/internal/scheduler/validation/ValidReportIntervalValidator.java
+package com.example.tasktracker.backend.internal.scheduler.validation;
+
+import com.example.tasktracker.backend.internal.scheduler.config.SchedulerSupportApiProperties;
+import com.example.tasktracker.backend.internal.scheduler.dto.UserTaskReportRequest;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+@Component
+@RequiredArgsConstructor
+public class ValidReportIntervalValidator implements ConstraintValidator<ValidReportInterval, UserTaskReportRequest> {
+
+    private final Clock clock;
+    private final SchedulerSupportApiProperties properties;
+
+    @Override
+    public boolean isValid(UserTaskReportRequest request, ConstraintValidatorContext context) {
+        if (request == null || request.getFrom() == null || request.getTo() == null) {
+            return true; // Проверку на null делают @NotNull на полях
+        }
+
+        boolean isValid = true;
+        Instant from = request.getFrom();
+        Instant to = request.getTo();
+
+        if (!from.isBefore(to)) {
+            isValid = false;
+            addConstraintViolation(context, "{internal.report.validation.fromBeforeTo}");
+        }
+
+        long maxIntervalDays = properties.getUserTaskReport().getMaxIntervalDays();
+        if (Duration.between(from, to).toDays() > maxIntervalDays) {
+            isValid = false;
+            addConstraintViolation(context, "{internal.report.validation.intervalTooLarge}", "to", maxIntervalDays);
+        }
+
+        long maxAgeDays = properties.getUserTaskReport().getMaxAgeDays();
+        if (to.isBefore(clock.instant().minus(maxAgeDays, ChronoUnit.DAYS))) {
+            isValid = false;
+            addConstraintViolation(context, "{internal.report.validation.intervalTooOld}", "to", maxAgeDays);
+        }
+
+        return isValid;
+    }
+
+    private void addConstraintViolation(ConstraintValidatorContext context, String messageTemplate, Object... args) {
+        context.disableDefaultConstraintViolation();
+        context.buildConstraintViolationWithTemplate(String.format(messageTemplate, args))
+                .addConstraintViolation();
+    }
+
+    private void addConstraintViolation(ConstraintValidatorContext context, String messageTemplate, String propertyNode, Object... args) {
+        context.disableDefaultConstraintViolation();
+        context.buildConstraintViolationWithTemplate(String.format(messageTemplate, args))
+                .addPropertyNode(propertyNode)
+                .addConstraintViolation();
+    }
+}

--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/internal/scheduler/web/SchedulerSupportController.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/internal/scheduler/web/SchedulerSupportController.java
@@ -1,22 +1,26 @@
 package com.example.tasktracker.backend.internal.scheduler.web;
 
 import com.example.tasktracker.backend.internal.scheduler.dto.PaginatedUserIdsResponse;
+import com.example.tasktracker.backend.internal.scheduler.dto.UserTaskReport;
+import com.example.tasktracker.backend.internal.scheduler.dto.UserTaskReportRequest;
 import com.example.tasktracker.backend.internal.scheduler.service.SystemDataProvisionService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/internal/scheduler-support")
@@ -54,5 +58,27 @@ public class SchedulerSupportController {
         log.info("Successfully returned {} user IDs. HasNextPage: {}.",
                 response.getData().size(), response.getPageInfo().isHasNextPage());
         return ResponseEntity.ok(response);
+    }
+
+    @Operation(
+            summary = "Получить отчеты по задачам для списка пользователей",
+            description = "Принимает список ID пользователей и временной интервал, возвращает агрегированные отчеты."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "Отчеты успешно сформированы.",
+                    content = @Content(mediaType = "application/json",
+                    array = @ArraySchema(schema = @Schema(implementation = UserTaskReport.class)))
+            ),
+            @ApiResponse(responseCode = "401", ref = "#/components/responses/UnauthorizedApiKey"),
+            @ApiResponse(responseCode = "400", ref = "#/components/responses/BadRequestGeneral")
+    })
+    @PostMapping("/tasks/user-reports")
+    public ResponseEntity<List<UserTaskReport>> getTaskReportsForUsers(
+            @Valid @RequestBody UserTaskReportRequest request) {
+        log.info("Processing request for task reports for {} user(s).", request.getUserIds().size());
+        List<UserTaskReport> reports = provisionService.getTaskReportsForUsers(request);
+        log.info("Successfully returned {} task reports.", reports.size());
+        return ResponseEntity.ok(reports);
     }
 }

--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/task/repository/JdbcTaskQueryRepository.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/task/repository/JdbcTaskQueryRepository.java
@@ -1,0 +1,124 @@
+package com.example.tasktracker.backend.task.repository;
+
+import com.example.tasktracker.backend.internal.scheduler.dto.TaskInfo;
+import com.example.tasktracker.backend.internal.scheduler.dto.UserTaskReport;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.CollectionUtils;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Repository
+@RequiredArgsConstructor
+@Slf4j
+public class JdbcTaskQueryRepository implements TaskQueryRepository {
+
+    private final JdbcClient jdbcClient;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public List<UserTaskReport> findTaskReportsForUsers(@NonNull List<Long> userIds, @NonNull Instant from, @NonNull Instant to) {
+        if (CollectionUtils.isEmpty(userIds)) {
+            return Collections.emptyList();
+        }
+
+        final String sql = """
+                WITH user_ids_to_process AS (
+                    SELECT id FROM unnest(:userIdsArray::bigint[]) AS u(id)
+                ),
+                ranked_tasks AS (
+                    SELECT
+                        t.user_id,
+                        t.id AS task_id,
+                        t.title AS task_title,
+                        t.status,
+                        t.created_at,
+                        t.completed_at,
+                        CASE
+                            WHEN t.status = 'PENDING' THEN ROW_NUMBER() OVER (PARTITION BY t.user_id ORDER BY t.created_at ASC)
+                            ELSE NULL
+                        END as pending_rank
+                    FROM tasks t
+                    WHERE
+                        EXISTS (SELECT 1 FROM user_ids_to_process u WHERE u.id = t.user_id)
+                      AND
+                        (t.status = 'PENDING' OR (t.status = 'COMPLETED' AND t.completed_at >= :from AND t.completed_at < :to))
+                ),
+                aggregated_reports AS (
+                    SELECT
+                        user_id,
+                        jsonb_agg(jsonb_build_object('id', task_id, 'title', task_title) ORDER BY created_at ASC)
+                            FILTER (WHERE status = 'PENDING' AND pending_rank <= 5) AS pending_tasks,
+                        jsonb_agg(jsonb_build_object('id', task_id, 'title', task_title) ORDER BY completed_at DESC)
+                            FILTER (WHERE status = 'COMPLETED') AS completed_tasks
+                    FROM ranked_tasks
+                    GROUP BY user_id
+                )
+                SELECT
+                    ar.user_id,
+                    u.email,
+                    COALESCE(ar.pending_tasks, '[]'::jsonb) AS pendingTasks,
+                    COALESCE(ar.completed_tasks, '[]'::jsonb) AS completedTasks
+                FROM
+                    aggregated_reports ar
+                JOIN
+                    users u ON ar.user_id = u.id
+                """;
+
+        String idsArray = userIds.stream().map(String::valueOf).collect(Collectors.joining(",","{","}"));
+
+        return jdbcClient.sql(sql)
+                .param("userIdsArray", idsArray)
+                .param("from", OffsetDateTime.ofInstant(from, ZoneOffset.UTC))
+                .param("to", OffsetDateTime.ofInstant(to, ZoneOffset.UTC))
+                .query(new UserTaskReportRowMapper(objectMapper))
+                .list();
+    }
+
+    private static class UserTaskReportRowMapper implements RowMapper<UserTaskReport> {
+        private final ObjectMapper objectMapper;
+        private final TypeReference<List<TaskInfo>> taskInfoListTypeRef = new TypeReference<>() {};
+
+        public UserTaskReportRowMapper(ObjectMapper objectMapper) {
+            this.objectMapper = objectMapper;
+        }
+
+        @Override
+        public UserTaskReport mapRow(@NonNull ResultSet rs, int rowNum) throws SQLException {
+            Long userId = rs.getLong("user_id");
+            String email = rs.getString("email");
+
+            UserTaskReport report = new UserTaskReport(userId,email);
+
+            try {
+                List<TaskInfo> pending = objectMapper.readValue(rs.getString("pendingTasks"), taskInfoListTypeRef);
+                List<TaskInfo> completed = objectMapper.readValue(rs.getString("completedTasks"), taskInfoListTypeRef);
+
+                if (pending != null) {
+                    report.getTasksPending().addAll(pending);
+                }
+                if (completed != null) {
+                    report.getTasksCompleted().addAll(completed);
+                }
+            } catch (JsonProcessingException e) {
+                log.error("Failed to parse TaskInfo JSON from database for user ID: {}. Invalid JSON in ResultSet.", userId, e);
+                throw new SQLException("Failed to parse TaskInfo JSON from database for user ID: " + userId, e);
+            }
+            return report;
+        }
+    }
+}

--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/task/repository/TaskQueryRepository.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/task/repository/TaskQueryRepository.java
@@ -1,0 +1,22 @@
+package com.example.tasktracker.backend.task.repository;
+
+import com.example.tasktracker.backend.internal.scheduler.dto.UserTaskReport;
+import org.springframework.stereotype.Repository;
+
+import java.time.Instant;
+import java.util.List;
+
+@Repository
+public interface TaskQueryRepository {
+
+    /**
+     * Находит и агрегирует отчеты по задачам для указанного списка пользователей
+     * за заданный временной интервал.
+     *
+     * @param userIds Список ID пользователей.
+     * @param from    Начало временного интервала (включительно).
+     * @param to      Конец временного интервала (исключительно).
+     * @return Список отчетов {@link UserTaskReport}.
+     */
+    List<UserTaskReport> findTaskReportsForUsers(List<Long> userIds, Instant from, Instant to);
+}

--- a/task-tracker-backend/src/main/resources/application.yml
+++ b/task-tracker-backend/src/main/resources/application.yml
@@ -16,7 +16,7 @@ spring:
     enabled: true
     change-log: classpath:/db/changelog/db.changelog-master.yaml
   messages:
-    basename: i18n/config/validation,i18n/common/messages,i18n/security/messages, i18n/user/messages, i18n/task/messages
+    basename: i18n/internal/messages,i18n/config/validation,i18n/common/messages,i18n/security/messages, i18n/user/messages, i18n/task/messages
     encoding: UTF-8
     fallback-to-system-locale: false
   jackson:

--- a/task-tracker-backend/src/main/resources/db/changelog/changesets/2025-06-21-14-00-add-indexes-for-task-reports.yaml
+++ b/task-tracker-backend/src/main/resources/db/changelog/changesets/2025-06-21-14-00-add-indexes-for-task-reports.yaml
@@ -1,0 +1,31 @@
+databaseChangeLog:
+  - changeSet:
+      id: 7
+      author: dailar401@gmail.com
+      comment: "Drop old, less efficient index on tasks(user_id) for pending status"
+      changes:
+        - dropIndex:
+            indexName: "idx_tasks_user_id_where_status_pending"
+            tableName: "tasks"
+
+  - changeSet:
+      id: 8
+      author: dailar401@gmail.com
+      comment: "Add partial composite index for pending tasks report"
+      changes:
+        - sql:
+            comment: "Create covering partial index on (user_id, created_at) for PENDING tasks"
+            dbms: "postgresql"
+            endDelimiter: ";"
+            sql: "CREATE INDEX idx_tasks_user_id_created_at_pending ON tasks (user_id, created_at ASC) WHERE status = 'PENDING';"
+
+  - changeSet:
+      id: 9
+      author: dailar401@gmail.com
+      comment: "Add partial composite index for completed tasks report"
+      changes:
+        - sql:
+            comment: "Create covering partial index on (user_id, completed_at) for COMPLETED tasks"
+            dbms: "postgresql"
+            endDelimiter: ";"
+            sql: "CREATE INDEX idx_tasks_user_id_completed_at_completed ON tasks (user_id, completed_at DESC) WHERE status = 'COMPLETED';"

--- a/task-tracker-backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/task-tracker-backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -9,3 +9,5 @@ databaseChangeLog:
       file: db/changelog/changesets/2025-05-31-create-undelivered-email-commands-table.yaml
   - include:
       file: db/changelog/changesets/2025-06-17-09-00-add-version-to-tasks-table.yaml
+  - include:
+      file: db/changelog/changesets/2025-06-21-14-00-add-indexes-for-task-reports.yaml

--- a/task-tracker-backend/src/main/resources/i18n/internal/messages.properties
+++ b/task-tracker-backend/src/main/resources/i18n/internal/messages.properties
@@ -6,5 +6,5 @@ internal.report.to.notNull=Report end time ('to') cannot be null.
 # Class-level validation for report request
 internal.report.validation.invalidInterval.default=Invalid report time interval provided.
 internal.report.validation.fromBeforeTo='from' date must be before 'to' date.
-internal.report.validation.intervalTooLarge=The requested report interval exceeds the maximum allowed of %d days.
-internal.report.validation.intervalTooOld=Reports cannot be requested for periods ending more than %d days ago.
+internal.report.validation.intervalTooLarge=The requested report interval exceeds the maximum allowed of {maxDays} days.
+internal.report.validation.intervalTooOld=Reports cannot be requested for periods ending more than {maxAge} days ago.

--- a/task-tracker-backend/src/main/resources/i18n/internal/messages.properties
+++ b/task-tracker-backend/src/main/resources/i18n/internal/messages.properties
@@ -1,0 +1,10 @@
+# Validation for scheduled report API DTOs
+internal.report.userIds.notNull=User ID list cannot be null.
+internal.report.from.notNull=Report start time ('from') cannot be null.
+internal.report.to.notNull=Report end time ('to') cannot be null.
+
+# Class-level validation for report request
+internal.report.validation.invalidInterval.default=Invalid report time interval provided.
+internal.report.validation.fromBeforeTo='from' date must be before 'to' date.
+internal.report.validation.intervalTooLarge=The requested report interval exceeds the maximum allowed of %d days.
+internal.report.validation.intervalTooOld=Reports cannot be requested for periods ending more than %d days ago.

--- a/task-tracker-backend/src/test/java/com/example/tasktracker/backend/task/repository/TaskQueryRepositoryIT.java
+++ b/task-tracker-backend/src/test/java/com/example/tasktracker/backend/task/repository/TaskQueryRepositoryIT.java
@@ -1,0 +1,175 @@
+package com.example.tasktracker.backend.task.repository;
+
+import com.example.tasktracker.backend.internal.scheduler.dto.TaskInfo;
+import com.example.tasktracker.backend.internal.scheduler.dto.UserTaskReport;
+import com.example.tasktracker.backend.task.entity.Task;
+import com.example.tasktracker.backend.task.entity.TaskStatus;
+import com.example.tasktracker.backend.user.entity.User;
+import com.example.tasktracker.backend.user.repository.UserRepository;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Testcontainers
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("ci")
+@DisplayName("Интеграционные тесты для TaskQueryRepository")
+class TaskQueryRepositoryIT {
+
+    @Container
+    @ServiceConnection
+    static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:17.4-alpine");
+
+    @Autowired private TaskQueryRepository taskQueryRepository;
+    @Autowired private UserRepository userRepository;
+    @Autowired private TaskRepository taskRepository;
+    @Autowired private Clock clock;
+
+    private User user1_mixed, user2_pendingOnly, user3_noRelevantTasks;
+
+    @BeforeEach
+    void setupTestData() {
+        // Создаем пользователей
+        user1_mixed = userRepository.save(new User(null, "user1@test.com", "p", null, null));
+        user2_pendingOnly = userRepository.save(new User(null, "user2@test.com", "p", null, null));
+        user3_noRelevantTasks = userRepository.save(new User(null, "user3@test.com", "p", null, null));
+
+        Instant now = clock.instant();
+
+        // -- Задачи для user1 (смешанный случай) --
+        // 6 несделанных, чтобы проверить лимит в 5 и сортировку (старые первыми)
+        for (int i = 0; i < 6; i++) {
+            createTask("U1-Pending-" + i, user1_mixed, TaskStatus.PENDING, now.minus(i, ChronoUnit.DAYS), null);
+        }
+        // 7 недавно сделанных, чтобы проверить отсутствие лимита и сортировку (новые первыми)
+        for (int i = 0; i < 7; i++) {
+            createTask("U1-Completed-Recent-" + i, user1_mixed, TaskStatus.COMPLETED, now, now.minus(i, ChronoUnit.HOURS));
+        }
+
+        // -- Задачи для user2 (только PENDING) --
+        createTask("U2-Pending-Old", user2_pendingOnly, TaskStatus.PENDING, now.minus(2, ChronoUnit.DAYS), null);
+        createTask("U2-Pending-New", user2_pendingOnly, TaskStatus.PENDING, now.minus(1, ChronoUnit.DAYS), null);
+
+        // -- Задачи для user3 (только старые COMPLETED) --
+        createTask("U3-Completed-Old", user3_noRelevantTasks, TaskStatus.COMPLETED, now, now.minus(30, ChronoUnit.DAYS));
+    }
+
+    @AfterEach
+    void cleanup() {
+        userRepository.deleteAll();
+    }
+
+    private void createTask(String title, User user, TaskStatus status, Instant createdAt, Instant completedAt) {
+        Task task = new Task();
+        task.setTitle(title);
+        task.setUser(user);
+        task.setStatus(status);
+        task.setCreatedAt(createdAt);
+        task.setUpdatedAt(createdAt);
+        if (completedAt != null) {
+            task.setCompletedAt(completedAt);
+        }
+        taskRepository.save(task);
+    }
+
+    private UserTaskReport findReportForUser(List<UserTaskReport> reports, Long userId) {
+        return reports.stream().filter(r -> r.getUserId().equals(userId)).findFirst().orElse(null);
+    }
+
+    @Nested
+    @DisplayName("Проверка полноты и корректности отчетов")
+    class ReportCorrectnessTests {
+
+        @Test
+        @DisplayName("TC-1,7,8,9,10: Смешанный случай - должен вернуть корректный отчет с лимитами и сортировкой")
+        void findTaskReports_forMixedCaseUser_shouldReturnCorrectlyLimitedAndSortedReport() {
+            Instant from = clock.instant().minus(24, ChronoUnit.HOURS);
+            Instant to = clock.instant().plus(1, ChronoUnit.MINUTES); // +1 минута для захвата now()
+
+            List<UserTaskReport> reports = taskQueryRepository.findTaskReportsForUsers(List.of(user1_mixed.getId()), from, to);
+
+            assertThat(reports).hasSize(1);
+            UserTaskReport report = reports.get(0);
+
+            assertThat(report.getUserId()).isEqualTo(user1_mixed.getId());
+            assertThat(report.getEmail()).isEqualTo(user1_mixed.getEmail());
+
+            assertThat(report.getTasksPending()).as("PENDING tasks should be the 5 oldest ones (created_at ASC)")
+                    .hasSize(5)
+                    .extracting(TaskInfo::getTitle)
+                    .containsExactly("U1-Pending-5", "U1-Pending-4", "U1-Pending-3", "U1-Pending-2", "U1-Pending-1");
+
+            assertThat(report.getTasksCompleted()).as("COMPLETED tasks should include all 7 recent ones (completed_at DESC)")
+                    .hasSize(7)
+                    .extracting(TaskInfo::getTitle)
+                    .containsExactly("U1-Completed-Recent-0", "U1-Completed-Recent-1", "U1-Completed-Recent-2", "U1-Completed-Recent-3", "U1-Completed-Recent-4", "U1-Completed-Recent-5", "U1-Completed-Recent-6");
+        }
+
+        @Test
+        @DisplayName("TC-2: Пользователь только с PENDING задачами")
+        void findTaskReports_forUserWithOnlyPendingTasks_shouldReturnPendingTasksAndEmptyCompleted() {
+            Instant from = clock.instant().minus(24, ChronoUnit.HOURS);
+            Instant to = clock.instant().plus(1, ChronoUnit.MINUTES);
+
+            List<UserTaskReport> reports = taskQueryRepository.findTaskReportsForUsers(List.of(user2_pendingOnly.getId()), from, to);
+
+            assertThat(reports).hasSize(1);
+            UserTaskReport report = reports.get(0);
+            assertThat(report.getEmail()).isEqualTo(user2_pendingOnly.getEmail());
+            assertThat(report.getTasksPending()).extracting(TaskInfo::getTitle).containsExactlyInAnyOrder("U2-Pending-Old", "U2-Pending-New");
+            assertThat(report.getTasksCompleted()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("TC-3: Пользователь только с RECENTLY COMPLETED задачами")
+        void findTaskReports_forUserWithOnlyRecentCompleted_shouldReturnCompletedTasksAndEmptyPending() {
+            Instant from = clock.instant().minus(24, ChronoUnit.HOURS);
+            Instant to = clock.instant().plus(1, ChronoUnit.MINUTES);
+
+            List<UserTaskReport> reports = taskQueryRepository.findTaskReportsForUsers(List.of(user1_mixed.getId()), from, to);
+
+            // Проверяем, что отчет по user1 содержит выполненные задачи
+            UserTaskReport report1 = findReportForUser(reports, user1_mixed.getId());
+            assertThat(report1).isNotNull();
+            assertThat(report1.getTasksCompleted()).isNotEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("Проверка граничных случаев и отсутствия данных")
+    class EdgeCaseTests {
+
+        @Test
+        @DisplayName("TC-4 & TC-5: Пользователи без релевантных задач не должны попадать в отчет")
+        void findTaskReports_forUsersWithNoRelevantTasks_shouldReturnEmptyList() {
+            Instant from = clock.instant().minus(24, ChronoUnit.HOURS);
+            Instant to = clock.instant().plus(1, ChronoUnit.MINUTES);
+
+            List<UserTaskReport> reports = taskQueryRepository.findTaskReportsForUsers(
+                    List.of(user3_noRelevantTasks.getId()), from, to
+            );
+
+            assertThat(reports).isEmpty();
+        }
+
+        @Test
+        @DisplayName("TC-6: Пустой список ID на входе должен вернуть пустой список")
+        void findTaskReports_whenUserIdsListIsEmpty_shouldReturnEmptyList() {
+            List<UserTaskReport> reports = taskQueryRepository.findTaskReportsForUsers(Collections.emptyList(), clock.instant(), clock.instant());
+            assertThat(reports).isNotNull().isEmpty();
+        }
+    }
+}

--- a/task-tracker-backend/src/test/java/com/example/tasktracker/backend/test/util/TestClockConfiguration.java
+++ b/task-tracker-backend/src/test/java/com/example/tasktracker/backend/test/util/TestClockConfiguration.java
@@ -1,0 +1,21 @@
+package com.example.tasktracker.backend.test.util;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+@TestConfiguration
+public class TestClockConfiguration {
+
+    public static final Instant FIXED_TEST_INSTANT = Instant.parse("2025-07-01T10:00:00Z");
+
+    @Bean
+    @Primary // Переопределяем основной бин Clock в тестовом контексте
+    public Clock testClock() {
+        return Clock.fixed(FIXED_TEST_INSTANT, ZoneOffset.UTC);
+    }
+}


### PR DESCRIPTION
Этот Pull Request реализует технический эпик **API для поддержки сервиса-планировщика**, в частности, задачу `API-SCHED-01.3` и все связанные с ней подзадачи. Он предоставляет новый, безопасный и производительный внутренний API для получения агрегированных отчетов по задачам пользователей.

**Основной функционал:**
*   Добавлен новый эндпоинт `POST /api/v1/internal/tasks/user-reports`, который позволяет внутреннему сервису (планировщику) запрашивать отчеты по задачам для списка пользователей за определенный временной интервал.

**Ключевые изменения и улучшения:**
*   **Производительный SQL:** Реализован сложный нативный SQL-запрос с `UNNEST` и `EXISTS`, который эффективно агрегирует все необходимые данные за один вызов к базе данных. Это решение масштабируемо и готово к большим объемам данных.
*   **Оптимизация БД:** Добавлены два новых композитных частичных индекса для таблицы `tasks`, которые покрывают условия запроса и обеспечивают высокую производительность. Старый, менее эффективный индекс удален.
*   **Современный Data-Access Layer:** Для выполнения запроса используется `JdbcClient`, что делает код репозитория чистым и современным. Реализован безопасный способ передачи списков ID в PostgreSQL.
*   **Надежный API-контракт:** API принимает точные временные границы (`from`, `to`) для обеспечения детерминированности отчетов. Реализована бизнес-валидация на стороне сервера для предотвращения некорректных запросов (проверка `from < to`, максимальной длительности интервала и "старости" отчета).
*   **OpenAPI Документация:** Новый эндпоинт и его DTO полностью задокументированы для потребителей внутреннего API.

### **Реализованный функционал (Implemented Functionality)**

*   **API Эндпоинт:** `POST /api/v1/internal/scheduler-support/tasks/user-reports`.
*   **Аутентификация:** Эндпоинт защищен механизмом `X-API-Key`.
*   **Запрос:** Принимает `UserTaskReportRequest`, содержащий `userIds`, `from` (Instant), `to` (Instant).
*   **Ответ:** При успехе возвращает HTTP `200 OK` со списком `UserTaskReport`. Каждый отчет содержит `userId`, `email` и два списка задач:
    *   `tasksPending`: до 5 самых старых невыполненных задач.
    *   `tasksCompleted`: все задачи, выполненные в заданном интервале.
*   **Обработка ошибок:**
    *   **400 Bad Request:** При невалидном теле запроса или если параметры (`from`, `to`) не проходят бизнес-валидацию (интервал некорректен, слишком большой или старый).
    *   **401 Unauthorized:** При отсутствии или невалидности `X-API-Key`.
*   **Компоненты:**
    *   **`TaskQueryRepository.java`:** Новый репозиторий для выполнения сложных "читающих" запросов.
    *   **`SystemDataProvisionService.java`:** Добавлен метод `getTaskReportsForUsers` с логикой валидации.
    *   **`SchedulerSupportController.java`:** Добавлен метод `getTaskReportsForUsers`.
    *   **Новые DTO:** `TaskInfo`, `UserTaskReport`, `UserTaskReportRequest`.
    *   **Новые миграции:** Добавлены индексы для `tasks`, удален старый.

### **Критерии Приемки (Acceptance Criteria Checklist) для API-SCHED-01.3**

*   [x] **AC1: Эндпоинт реализован:** `POST /api/v1/internal/tasks/user-reports` создан.
*   [x] **AC2: Реализована SQL-логика:** Сложный SQL с `UNNEST`, `EXISTS`, `jsonb_agg` и сортировкой реализован в `JdbcTaskQueryRepository`.
*   [x] **AC3: Формат ответа:** API возвращает `List<UserTaskReport>` в корректном формате.
*   [x] **AC4: Обработка граничных случаев:** Пустой список ID, отсутствие релевантных задач.
*   [x] **AC5: Безопасность:** Эндпоинт защищен `ApiKeyAuthFilter`.
*   [x] **AC6: Производительность:** Вся агрегация происходит в одном SQL-запросе. Новые индексы созданы.
*   [x] **AC7: Тесты:** Написаны юнит-тесты для сервиса и исчерпывающие интеграционные тесты для репозитория и контроллера.
*   [x] **AC8: Документация:** OpenAPI спецификация обновлена.

### **Соответствие Definition of Done (DoD Checklist)**

*   [x] Код написан и соответствует стандартам проекта.
*   [x] Javadoc написан/обновлен для всех новых публичных компонентов.
*   [x] Реализованы все AC для `API-SCHED-01.3`.
*   [x] Юнит-тесты написаны и проходят.
*   [x] Интеграционные тесты написаны и проходят.
*   [x] Покрытие кода тестами (JaCoCo) проверено.
*   [x] Код готов к Code Review.
*   [x] CI/CD пайплайн (Jenkins) должен успешно пройти для этого кода.
*   [x] Документация (OpenAPI, Javadoc) обновлена.
*   [x] Новых критических технических задач или техдолга не выявлено.

### **Как тестировать (How to Test Manually)**

1.  Запустить приложение и зависимости (`docker-compose up -d`).
2.  Создать нескольких пользователей с разными наборами задач (pending, completed recent, completed old) через публичное API (например, с помощью Postman).
3.  Получить валидный `X-API-Key` из `application-dev.yml`.
4.  Выполнить `POST /api/v1/internal/scheduler-support/tasks/user-reports` с помощью Postman или `curl`, указав в заголовке `X-API-Key`.
    *   В теле запроса передать JSON с `userIds`, `from`, `to`.
    *   Ожидаемый ответ: 200 OK, JSON-массив с отчетами.
5.  Проверить негативные сценарии:
    *   Отправить запрос без `X-API-Key` (ожидается 401).
    *   Отправить запрос с невалидным интервалом (например, `from` после `to`) (ожидается 400).

### **Дополнительные Замечания**
*   Этот PR является ключевым для разблокировки разработки сервиса `task-tracker-scheduler`.