### PR TITLE
feat(scheduler): Implement Daily Report Producer Job Logic

### DIFF
--- a/task-tracker-scheduler/src/main/java/com/example/tasktracker/scheduler/job/dailyreport/DailyTaskReportJobTrigger.java
+++ b/task-tracker-scheduler/src/main/java/com/example/tasktracker/scheduler/job/dailyreport/DailyTaskReportJobTrigger.java
@@ -1,0 +1,57 @@
+package com.example.tasktracker.scheduler.job.dailyreport;
+
+import com.example.tasktracker.scheduler.common.MdcKeys;
+import com.example.tasktracker.scheduler.job.dailyreport.config.DailyReportJobProperties;
+import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.core.LockConfiguration;
+import net.javacrumbs.shedlock.core.LockingTaskExecutor;
+import org.slf4j.MDC;
+import org.springframework.scheduling.annotation.Scheduled;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+@Slf4j
+public class DailyTaskReportJobTrigger {
+
+    private final LockingTaskExecutor lockingTaskExecutor;
+    private final DailyTaskReportProducerJob executionService;
+    private final DailyReportJobProperties jobProperties;
+    private final Clock clock;
+
+    public DailyTaskReportJobTrigger(LockingTaskExecutor lockingTaskExecutor,
+                                     DailyTaskReportProducerJob executionService,
+                                     DailyReportJobProperties jobProperties,
+                                     Clock clock) {
+        this.lockingTaskExecutor = lockingTaskExecutor;
+        this.executionService = executionService;
+        this.jobProperties = jobProperties;
+        this.clock = clock;
+    }
+
+    @Scheduled(cron = "${app.scheduler.jobs.daily-task-reports.cron}")
+    public void trigger() {
+        final LocalDate reportDate = LocalDate.now(clock).minusDays(1); // Отчет всегда за вчера
+        final String jobName = jobProperties.getJobName();
+
+        try (
+                MDC.MDCCloseable ignoredJobName = MDC.putCloseable(MdcKeys.JOB_NAME, jobName);
+                MDC.MDCCloseable ignoredReportDate = MDC.putCloseable(MdcKeys.REPORT_DATE,
+                        reportDate.format(DateTimeFormatter.ISO_LOCAL_DATE))
+        ) {
+            final LockConfiguration lockConfig = new LockConfiguration(
+                    clock.instant(),
+                    jobName,
+                    jobProperties.getShedlock().getLockAtMostFor(),
+                    jobProperties.getShedlock().getLockAtLeastFor()
+            );
+
+            log.debug("Triggering execution with lock configuration: {}", lockConfig);
+            lockingTaskExecutor.executeWithLock(
+                    (Runnable) () -> executionService.execute(reportDate),
+                    lockConfig
+            );
+        }
+    }
+}

--- a/task-tracker-scheduler/src/main/java/com/example/tasktracker/scheduler/job/dailyreport/DailyTaskReportProducerJob.java
+++ b/task-tracker-scheduler/src/main/java/com/example/tasktracker/scheduler/job/dailyreport/DailyTaskReportProducerJob.java
@@ -1,0 +1,212 @@
+package com.example.tasktracker.scheduler.job.dailyreport;
+
+import com.example.tasktracker.scheduler.common.MdcKeys;
+import com.example.tasktracker.scheduler.job.JobStateRepository;
+import com.example.tasktracker.scheduler.job.dailyreport.client.UserIdsFetcherClient;
+import com.example.tasktracker.scheduler.job.dailyreport.client.dto.PaginatedUserIdsResponse;
+import com.example.tasktracker.scheduler.job.dailyreport.config.DailyReportJobProperties;
+import com.example.tasktracker.scheduler.job.dailyreport.messaging.event.UserSelectedForDailyReportEvent;
+import com.example.tasktracker.scheduler.job.dto.CursorPayload;
+import com.example.tasktracker.scheduler.job.dto.JobExecutionState;
+import com.example.tasktracker.scheduler.job.dto.JobStatus;
+import com.example.tasktracker.scheduler.metrics.Metric;
+import com.example.tasktracker.scheduler.metrics.MetricsReporter;
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.core.LockExtender;
+import org.slf4j.MDC;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.lang.Nullable;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Сервис, инкапсулирующий основную бизнес-логику джобы-продюсера
+ * для ежедневных отчетов по задачам.
+ * <p>
+ * Эта джоба отвечает за итеративную выборку ID пользователей из
+ * backend-сервиса и публикацию событий в Kafka для их последующей
+ * асинхронной обработки.
+ * </p>
+ * <p>
+ * Использует Redis для хранения состояния (курсора) для обеспечения
+ * возобновляемости и идемпотентности.
+ * </p>
+ */
+@Slf4j
+public class DailyTaskReportProducerJob {
+
+    private final JobStateRepository jobStateRepository;
+    private final UserIdsFetcherClient userIdsFetcherClient;
+    private final KafkaTemplate<String, UserSelectedForDailyReportEvent> kafkaTemplate;
+    private final Executor kafkaCallbackExecutor;
+    private final DailyReportJobProperties jobProperties;
+    private final String producerTopicName;
+    private final MetricsReporter metrics;
+    private final TypeReference<JobExecutionState<CursorPayload>> stateTypeReference = new TypeReference<>() {
+    };
+
+    private static final String STATUS_SUCCESS = "SUCCESS";
+    private static final String STATUS_FAILED = "FAILED";
+
+
+    public DailyTaskReportProducerJob(JobStateRepository jobStateRepository,
+                                      UserIdsFetcherClient userIdsFetcherClient,
+                                      KafkaTemplate<String, UserSelectedForDailyReportEvent> kafkaTemplate,
+                                      Executor kafkaCallbackExecutor,
+                                      DailyReportJobProperties jobProperties,
+                                      MetricsReporter metrics) {
+        this.jobStateRepository = jobStateRepository;
+        this.userIdsFetcherClient = userIdsFetcherClient;
+        this.kafkaTemplate = kafkaTemplate;
+        this.kafkaCallbackExecutor = kafkaCallbackExecutor;
+        this.jobProperties = jobProperties;
+        this.producerTopicName = jobProperties.getKafkaTopicName();
+        this.metrics = metrics;
+    }
+
+    /**
+     * Основной метод выполнения джобы.
+     *
+     * @param reportDate Дата, за которую формируется отчет.
+     */
+    public void execute(@NonNull LocalDate reportDate) {
+        final String jobName = jobProperties.getJobName();
+        final String jobRunId = UUID.randomUUID().toString();
+
+        Timer.Sample sample = Timer.start();
+        String finalStatus = STATUS_SUCCESS;
+
+        try (
+                MDC.MDCCloseable ignoredRunId = MDC.putCloseable(MdcKeys.JOB_RUN_ID, jobRunId);
+                MDC.MDCCloseable ignoredJobName = MDC.putCloseable(MdcKeys.JOB_NAME, jobName);
+                MDC.MDCCloseable ignoredReportDate = MDC.putCloseable(MdcKeys.REPORT_DATE,
+                        reportDate.format(DateTimeFormatter.ISO_LOCAL_DATE))
+        ) {
+            log.info("Producer execution starting for job '{}', report date: {}.", jobName, reportDate);
+
+            try {
+                Optional<JobExecutionState<CursorPayload>> currentState = jobStateRepository
+                        .findState(jobName, reportDate, stateTypeReference);
+
+                if (isJobTerminated(currentState.orElse(null), reportDate)) {
+                    return;
+                }
+
+                String cursor = currentState.map(JobExecutionState::payload).map(CursorPayload::lastCursor).orElse(null);
+                boolean hasNextPage;
+
+                do {
+                    extendLockOrThrow(jobName);
+
+                    PaginatedUserIdsResponse response = userIdsFetcherClient.fetchUserIds(cursor, jobProperties.getPageSize());
+                    List<Long> userIds = response.userIds();
+
+                    long successfullySentCount = 0;
+                    if (!userIds.isEmpty()) {
+                        successfullySentCount = sendUserIdsToKafka(userIds, reportDate, jobRunId, jobName);
+                    }
+
+                    hasNextPage = response.pageInfo().hasNextPage();
+                    cursor = response.pageInfo().nextPageCursor();
+
+                    jobStateRepository.saveState(jobName, reportDate, JobExecutionState.inProgress(new CursorPayload(cursor)));
+
+                    if (successfullySentCount > 0) {
+                        metrics.incrementCounter(Metric.JOB_EVENTS_PUBLISHED, successfullySentCount, Tags.of("job_name", jobName));
+                    }
+
+                } while (hasNextPage);
+
+                jobStateRepository.saveState(jobName, reportDate, JobExecutionState.published());
+                log.info("Job '{}' for report date {} finished successfully.", jobName, reportDate);
+
+            } catch (Exception e) {
+                finalStatus = STATUS_FAILED;
+                metrics.incrementCounter(Metric.JOB_RUN_FAILURE, Tags.of("job_name", jobName));
+                log.error("Job '{}' for report date {} failed critically. It will be retried on the next schedule.",
+                        jobName, reportDate, e);
+                // НЕ сохраняем JobStatus.FAILED, чтобы разрешить автоматический ретрай при следующем запуске по cron.
+            }
+            finally {
+                Tags finalTags = Tags.of("job_name", jobName, "status", finalStatus);
+                sample.stop(metrics.getTimer(Metric.JOB_RUN_DURATION, finalTags));
+            }
+        }
+    }
+
+    private boolean isJobTerminated(@Nullable JobExecutionState<CursorPayload> currentState, LocalDate reportDate) {
+        if (currentState != null) {
+            JobStatus status = currentState.status();
+            if (status == JobStatus.PUBLISHED) {
+                log.info("Job '{}' for report date {} is already PUBLISHED. Skipping.",
+                        jobProperties.getJobName(), reportDate);
+                return true;
+            }
+            if (status == JobStatus.FAILED) {
+                log.warn("Job '{}' for report date {} has FAILED previously. Manual intervention required. Skipping.",
+                        jobProperties.getJobName(), reportDate);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void extendLockOrThrow(String jobName) {
+        try {
+            Duration extension = jobProperties.getShedlock().getLockAtMostFor().dividedBy(2);
+            LockExtender.extendActiveLock(extension, jobProperties.getShedlock().getLockAtLeastFor());
+        } catch (LockExtender.NoActiveLockException | LockExtender.LockCanNotBeExtendedException e) {
+            log.error("Failed to extend lock for job '{}'. It might have been already released. Aborting.", jobName, e);
+            throw e;
+        }
+    }
+
+    private long sendUserIdsToKafka(List<Long> userIds, LocalDate reportDate, String jobRunId, String jobName) {
+        AtomicBoolean hasFailures = new AtomicBoolean(false);
+        AtomicLong successCount = new AtomicLong(0);
+
+        List<CompletableFuture<Void>> futures = userIds.stream()
+                .map(userId -> {
+                    UserSelectedForDailyReportEvent event =
+                            new UserSelectedForDailyReportEvent(userId, jobRunId, reportDate);
+                    return kafkaTemplate.send(producerTopicName, event)
+                            .whenCompleteAsync((result, ex) -> {
+                                if (ex != null) {
+                                    hasFailures.set(true);
+                                    metrics.incrementCounter(Metric.JOB_KAFKA_SEND_FAILURE, Tags.of("job_name", jobName));
+                                    log.error("Job '{}': Failed to send event for userId: {}. Cause: {}",
+                                            jobName, userId, ex.getMessage());
+                                } else {
+                                    successCount.incrementAndGet();
+                                }
+                            }, kafkaCallbackExecutor);
+                })
+                .map(f -> f.<Void>thenApply(res -> null))
+                .toList();
+        try {
+            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+        } catch (Exception e) {
+            log.warn("Job '{}': One or more Kafka send futures completed exceptionally. Check previous logs.", jobName, e);
+        }
+
+        if (hasFailures.get()) {
+            throw new RuntimeException("Critical failure: unable to send all user ID events to Kafka. " +
+                    "Aborting batch to prevent data loss and ensure retry.");
+        }
+
+        return successCount.get();
+    }
+}

--- a/task-tracker-scheduler/src/main/java/com/example/tasktracker/scheduler/job/dailyreport/config/DailyReportJobConfiguration.java
+++ b/task-tracker-scheduler/src/main/java/com/example/tasktracker/scheduler/job/dailyreport/config/DailyReportJobConfiguration.java
@@ -1,0 +1,48 @@
+package com.example.tasktracker.scheduler.job.dailyreport.config;
+
+import com.example.tasktracker.scheduler.config.AppConfig;
+import com.example.tasktracker.scheduler.job.JobStateRepository;
+import com.example.tasktracker.scheduler.job.dailyreport.DailyTaskReportJobTrigger;
+import com.example.tasktracker.scheduler.job.dailyreport.DailyTaskReportProducerJob;
+import com.example.tasktracker.scheduler.job.dailyreport.client.UserIdsFetcherClient;
+import com.example.tasktracker.scheduler.job.dailyreport.messaging.event.UserSelectedForDailyReportEvent;
+import com.example.tasktracker.scheduler.metrics.MetricsReporter;
+import net.javacrumbs.shedlock.core.LockingTaskExecutor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.KafkaTemplate;
+
+import java.time.Clock;
+import java.util.concurrent.Executor;
+
+@Configuration
+@ConditionalOnProperty(name = "app.scheduler.jobs.daily-task-reports.enabled", havingValue = "true", matchIfMissing = true)
+public class DailyReportJobConfiguration {
+
+    @Bean
+    public DailyTaskReportProducerJob dailyTaskReportProducerJob(
+            JobStateRepository jobStateRepository,
+            UserIdsFetcherClient userIdsFetcherClient,
+            KafkaTemplate<String, UserSelectedForDailyReportEvent> kafkaTemplate,
+            @Qualifier(AppConfig.KAFKA_CALLBACK_EXECUTOR) Executor kafkaCallbackExecutor,
+            DailyReportJobProperties jobProperties,
+            MetricsReporter metrics) {
+        return new DailyTaskReportProducerJob(jobStateRepository,
+                userIdsFetcherClient,
+                kafkaTemplate,
+                kafkaCallbackExecutor,
+                jobProperties,
+                metrics);
+    }
+
+    @Bean
+    public DailyTaskReportJobTrigger dailyTaskReportJobTrigger(
+            LockingTaskExecutor lockingTaskExecutor,
+            DailyTaskReportProducerJob producerJob,
+            DailyReportJobProperties jobProperties,
+            Clock clock) {
+        return new DailyTaskReportJobTrigger(lockingTaskExecutor, producerJob, jobProperties, clock);
+    }
+}

--- a/task-tracker-scheduler/src/main/resources/application-ci.yml
+++ b/task-tracker-scheduler/src/main/resources/application-ci.yml
@@ -1,0 +1,8 @@
+otel:
+  sdk:
+    disabled: true
+
+app:
+    jobs:
+      daily-task-reports:
+        enabled: false

--- a/task-tracker-scheduler/src/test/java/com/example/tasktracker/scheduler/job/dailyreport/DailyTaskReportJobTriggerTest.java
+++ b/task-tracker-scheduler/src/test/java/com/example/tasktracker/scheduler/job/dailyreport/DailyTaskReportJobTriggerTest.java
@@ -1,0 +1,99 @@
+package com.example.tasktracker.scheduler.job.dailyreport;
+
+import com.example.tasktracker.scheduler.config.SchedulerAppProperties;
+import com.example.tasktracker.scheduler.job.dailyreport.config.DailyReportJobProperties;
+import net.javacrumbs.shedlock.core.LockConfiguration;
+import net.javacrumbs.shedlock.core.LockingTaskExecutor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Unit-тесты для DailyTaskReportJobTrigger")
+class DailyTaskReportJobTriggerTest {
+
+    @Mock
+    private LockingTaskExecutor mockLockingTaskExecutor;
+    @Mock
+    private DailyTaskReportProducerJob mockExecutionJob;
+    @Mock
+    private DailyReportJobProperties mockJobProperties;
+
+    // Фиксированное время: 2025-07-15 10:00 UTC
+    private final Clock fixedClock = Clock.fixed(Instant.parse("2025-07-15T10:00:00Z"), ZoneOffset.UTC);
+
+    private DailyTaskReportJobTrigger trigger;
+
+    @Captor
+    private ArgumentCaptor<Runnable> runnableCaptor;
+    @Captor
+    private ArgumentCaptor<LockConfiguration> lockConfigCaptor;
+
+    private static final String JOB_NAME = "daily-reports-job";
+
+    @BeforeEach
+    void setUp() {
+        // Настраиваем мок свойств
+        SchedulerAppProperties.ShedLockProperties shedLockProps = new SchedulerAppProperties.ShedLockProperties();
+        shedLockProps.setLockAtMostFor(Duration.ofMinutes(30));
+        shedLockProps.setLockAtLeastFor(Duration.ofSeconds(60));
+
+        when(mockJobProperties.getJobName()).thenReturn(JOB_NAME);
+        when(mockJobProperties.getShedlock()).thenReturn(shedLockProps);
+
+        trigger = new DailyTaskReportJobTrigger(mockLockingTaskExecutor, mockExecutionJob, mockJobProperties, fixedClock);
+    }
+
+    @Test
+    @DisplayName("TC-01: trigger() должен вызвать LockingTaskExecutor с корректной конфигурацией блокировки")
+    void trigger_shouldCallExecutorWithCorrectLockConfiguration() {
+        // Act
+        trigger.trigger();
+
+        // Assert
+        verify(mockLockingTaskExecutor).executeWithLock(any(Runnable.class), lockConfigCaptor.capture());
+        LockConfiguration capturedConfig = lockConfigCaptor.getValue();
+
+        assertThat(capturedConfig.getName()).isEqualTo(JOB_NAME);
+        assertThat(capturedConfig.getLockAtMostUntil()).isEqualTo(fixedClock.instant().plus(Duration.ofMinutes(30)));
+        assertThat(capturedConfig.getLockAtLeastUntil()).isEqualTo(fixedClock.instant().plus(Duration.ofSeconds(60)));
+    }
+
+    @Test
+    @DisplayName("TC-02: Выполняемый Runnable должен вызвать сервис с датой 'вчера'")
+    void trigger_runnableShouldCallServiceWithYesterdayDate() {
+        // Arrange
+        // Ожидаемая дата отчета: 2025-07-14 (вчера относительно 2025-07-15)
+        LocalDate expectedReportDate = LocalDate.of(2025, 7, 14);
+
+        // Act
+        trigger.trigger();
+
+        // Assert
+        // Перехватываем Runnable, который был передан в ShedLock
+        verify(mockLockingTaskExecutor).executeWithLock(runnableCaptor.capture(), any(LockConfiguration.class));
+        Runnable task = runnableCaptor.getValue();
+
+        // Выполняем Runnable вручную
+        task.run();
+
+        // Проверяем, что бизнес-логика была вызвана с правильной датой
+        verify(mockExecutionJob, times(1)).execute(eq(expectedReportDate));
+    }
+}

--- a/task-tracker-scheduler/src/test/java/com/example/tasktracker/scheduler/job/dailyreport/DailyTaskReportProducerJobIT.java
+++ b/task-tracker-scheduler/src/test/java/com/example/tasktracker/scheduler/job/dailyreport/DailyTaskReportProducerJobIT.java
@@ -1,0 +1,205 @@
+package com.example.tasktracker.scheduler.job.dailyreport;
+
+import com.example.tasktracker.scheduler.job.JobStateRepository;
+import com.example.tasktracker.scheduler.job.dto.CursorPayload;
+import com.example.tasktracker.scheduler.job.dto.JobExecutionState;
+import com.example.tasktracker.scheduler.job.dto.JobStatus;
+import com.example.tasktracker.scheduler.job.dailyreport.config.DailyReportJobProperties;
+import com.example.tasktracker.scheduler.job.dailyreport.messaging.event.UserSelectedForDailyReportEvent;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.redis.testcontainers.RedisContainer;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.errors.TopicExistsException;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.listener.KafkaMessageListenerContainer;
+import org.springframework.kafka.listener.MessageListener;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.kafka.KafkaContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.*;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+@SpringBootTest
+@ActiveProfiles("ci") // application-ci.yml (enabled=false), чтобы джоба не стартовала сама
+@Testcontainers
+@DisplayName("Daily Report Producer Job")
+class DailyTaskReportProducerJobIT {
+
+    @Container
+    static final RedisContainer redis = new RedisContainer(
+            DockerImageName.parse("redis:8-alpine"));
+
+    @Container
+    static final KafkaContainer kafka = new KafkaContainer(
+            DockerImageName.parse("apache/kafka-native:4.1.1"))
+            .waitingFor(Wait.forLogMessage(".*Kafka Server started.*", 1));
+
+    @RegisterExtension
+    static WireMockExtension wireMockServer = WireMockExtension.newInstance()
+            .options(wireMockConfig().dynamicPort())
+            .build();
+
+    @DynamicPropertySource
+    static void overrideProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.redis.host", redis::getHost);
+        registry.add("spring.data.redis.port", redis::getFirstMappedPort);
+        registry.add("spring.kafka.bootstrap-servers", kafka::getBootstrapServers);
+        // Динамический порт WireMock
+        registry.add("app.scheduler.backend-client.url", wireMockServer::baseUrl);
+    }
+    @Autowired
+    private DailyReportJobProperties dailyReportJobProperties;
+
+    @Autowired
+    private DailyTaskReportJobTrigger jobTrigger;
+
+    @Autowired
+    private JobStateRepository jobStateRepository;
+
+    @Autowired
+    private StringRedisTemplate redisTemplate;
+
+    @Autowired
+    private Clock clock;
+
+    @Value("${app.scheduler.jobs.daily-task-reports.kafka-topic-name}")
+    private String topicName;
+
+    // Kafka Consumer для проверки
+    private KafkaMessageListenerContainer<String, UserSelectedForDailyReportEvent> container;
+    private final BlockingQueue<ConsumerRecord<String, UserSelectedForDailyReportEvent>> records = new LinkedBlockingQueue<>();
+
+    @BeforeEach
+    void setUp() throws ExecutionException, InterruptedException, TimeoutException {
+        createKafkaTopic(topicName);
+
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.getBootstrapServers());
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "test-consumer-group");
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+
+        DefaultKafkaConsumerFactory<String, UserSelectedForDailyReportEvent> consumerFactory = new DefaultKafkaConsumerFactory<>(
+                props,
+                new StringDeserializer(),
+                new JsonDeserializer<>(UserSelectedForDailyReportEvent.class, false) // false = use headers off (если продюсер не шлет)
+        );
+
+        ContainerProperties containerProperties = new ContainerProperties(topicName);
+        container = new KafkaMessageListenerContainer<>(consumerFactory, containerProperties);
+        container.setupMessageListener((MessageListener<String, UserSelectedForDailyReportEvent>) records::add);
+        container.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        container.stop();
+        // Очищаем Redis перед следующим тестом
+        Objects.requireNonNull(redisTemplate.getConnectionFactory()).getConnection().serverCommands().flushAll();
+        records.clear();
+    }
+
+    private void createKafkaTopic(String topicName) throws ExecutionException, InterruptedException, TimeoutException {
+        try (AdminClient adminClient = AdminClient.create(Map.of(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.getBootstrapServers()))) {
+            NewTopic newTopic = new NewTopic(topicName, 1, (short) 1);
+            try {
+                adminClient.createTopics(Collections.singletonList(newTopic)).all().get(30, TimeUnit.SECONDS);
+            } catch (ExecutionException e) {
+                if (e.getCause() instanceof TopicExistsException) {
+                    // Топик уже существует, это нормально для ретраев при запуске тестов
+                    return;
+                }
+                throw e; // Пробросить любую другую ошибку
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("Happy Path: полный цикл от API до Kafka и Redis")
+    void executeJob_shouldFetchFromApiAndProduceToKafkaAndSaveState() {
+        // 1. Arrange: Настройка WireMock (Stubbing)
+        wireMockServer.stubFor(get(urlPathEqualTo("/api/v1/internal/scheduler-support/user-ids"))
+                .withQueryParam("limit", equalTo("1000"))
+                .withQueryParam("cursor", absent())
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                                {
+                                  "userIds": [101, 102],
+                                  "pageInfo": {
+                                    "hasNextPage": true,
+                                    "nextPageCursor": "next_page_cursor"
+                                  }
+                                }
+                                """)));
+
+        wireMockServer.stubFor(get(urlPathEqualTo("/api/v1/internal/scheduler-support/user-ids"))
+                .withQueryParam("cursor", equalTo("next_page_cursor"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                                {
+                                  "userIds": [103],
+                                  "pageInfo": {
+                                    "hasNextPage": false,
+                                    "nextPageCursor": null
+                                  }
+                                }
+                                """)));
+
+        LocalDate reportDate = LocalDate.now(clock).minusDays(1);
+
+        // 2. Act: Запуск джобы
+        jobTrigger.trigger();
+
+        // 3. Assert: Kafka (ждем 3 сообщения)
+        await().atMost(10, TimeUnit.SECONDS).until(() -> records.size() == 3);
+
+        ConsumerRecord<String, UserSelectedForDailyReportEvent> rec1 = records.poll();
+        assertThat(rec1.value().userId()).isEqualTo(101L);
+        assertThat(rec1.value().reportDate()).isEqualTo(reportDate);
+        assertThat(rec1.key()).isNull(); // Проверяем, что ключ null (Round Robin)
+
+        // 4. Assert: Redis
+        var stateOptional = jobStateRepository.findState(
+                dailyReportJobProperties.getJobName(),
+                reportDate,
+                new TypeReference<JobExecutionState<CursorPayload>>() {}
+        );
+
+        assertThat(stateOptional).isPresent();
+        assertThat(stateOptional.get().status()).isEqualTo(JobStatus.PUBLISHED);
+    }
+}

--- a/task-tracker-scheduler/src/test/java/com/example/tasktracker/scheduler/job/dailyreport/DailyTaskReportProducerJobTest.java
+++ b/task-tracker-scheduler/src/test/java/com/example/tasktracker/scheduler/job/dailyreport/DailyTaskReportProducerJobTest.java
@@ -1,0 +1,185 @@
+package com.example.tasktracker.scheduler.job.dailyreport;
+
+import com.example.tasktracker.scheduler.client.dto.PageInfo;
+import com.example.tasktracker.scheduler.job.JobStateRepository;
+import com.example.tasktracker.scheduler.job.dto.JobExecutionState;
+import com.example.tasktracker.scheduler.config.SchedulerAppProperties;
+import com.example.tasktracker.scheduler.job.dailyreport.client.UserIdsFetcherClient;
+import com.example.tasktracker.scheduler.job.dailyreport.client.dto.PaginatedUserIdsResponse;
+import com.example.tasktracker.scheduler.job.dailyreport.config.DailyReportJobProperties;
+import com.example.tasktracker.scheduler.job.dailyreport.messaging.event.UserSelectedForDailyReportEvent;
+import com.example.tasktracker.scheduler.metrics.Metric;
+import com.example.tasktracker.scheduler.metrics.MetricsReporter;
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
+import net.javacrumbs.shedlock.core.LockExtender;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("Unit-тесты для DailyTaskReportProducerJob")
+class DailyTaskReportProducerJobTest {
+
+    @Mock private JobStateRepository mockJobStateRepository;
+    @Mock private UserIdsFetcherClient mockUserIdsFetcherClient;
+    @Mock private KafkaTemplate<String, UserSelectedForDailyReportEvent> mockKafkaTemplate;
+    @Mock private Executor mockKafkaCallbackExecutor;
+    @Mock private DailyReportJobProperties mockJobProperties;
+    @Mock private Timer mockTimer;
+    @Mock private MetricsReporter mockMetrics;
+
+    private DailyTaskReportProducerJob job;
+    private MockedStatic<LockExtender> lockExtenderMockedStatic;
+
+    private static final String JOB_NAME = "daily-reports";
+    private static final String TOPIC_NAME = "test-topic";
+    private static final LocalDate REPORT_DATE = LocalDate.of(2025, 7, 15);
+    private static final int PAGE_SIZE = 100;
+
+    @BeforeEach
+    void setUp() {
+        when(mockJobProperties.getJobName()).thenReturn(JOB_NAME);
+        when(mockJobProperties.getKafkaTopicName()).thenReturn(TOPIC_NAME);
+        when(mockJobProperties.getPageSize()).thenReturn(PAGE_SIZE);
+
+        SchedulerAppProperties.ShedLockProperties shedLockProps = new SchedulerAppProperties.ShedLockProperties();
+        shedLockProps.setLockAtMostFor(Duration.ofMinutes(10));
+        shedLockProps.setLockAtLeastFor(Duration.ofSeconds(1));
+        when(mockJobProperties.getShedlock()).thenReturn(shedLockProps);
+
+        when(mockMetrics.getTimer(any(), any())).thenReturn(mockTimer);
+
+        doAnswer(invocation -> {
+            Runnable r = invocation.getArgument(0);
+            r.run();
+            return null;
+        }).when(mockKafkaCallbackExecutor).execute(any(Runnable.class));
+
+        job = new DailyTaskReportProducerJob(
+                mockJobStateRepository,
+                mockUserIdsFetcherClient,
+                mockKafkaTemplate,
+                mockKafkaCallbackExecutor,
+                mockJobProperties,
+                mockMetrics
+        );
+
+        lockExtenderMockedStatic = mockStatic(LockExtender.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        lockExtenderMockedStatic.close();
+    }
+
+    @Nested
+    @DisplayName("Проверка состояния")
+    class StateCheckTests {
+        @Test
+        @DisplayName("TC-01: Если состояние PUBLISHED, джоба должна завершиться без действий")
+        void execute_whenPublished_shouldDoNothing() {
+            // Arrange
+            when(mockJobStateRepository.findState(eq(JOB_NAME), eq(REPORT_DATE), any(TypeReference.class)))
+                    .thenReturn(Optional.of(JobExecutionState.published()));
+
+            // Act
+            job.execute(REPORT_DATE);
+
+            // Assert
+            verify(mockUserIdsFetcherClient, never()).fetchUserIds(any(), anyInt());
+        }
+
+        @Test
+        @DisplayName("TC-02: Если состояние FAILED, джоба должна завершиться (требует вмешательства)")
+        void execute_whenFailed_shouldDoNothing() {
+            // Arrange
+            when(mockJobStateRepository.findState(eq(JOB_NAME), eq(REPORT_DATE), any(TypeReference.class)))
+                    .thenReturn(Optional.of(JobExecutionState.failed("error")));
+
+            // Act
+            job.execute(REPORT_DATE);
+
+            // Assert
+            verify(mockUserIdsFetcherClient, never()).fetchUserIds(any(), anyInt());
+        }
+    }
+
+    @Nested
+    @DisplayName("Сценарии отказов (Failure Scenarios)")
+    class FailureTests {
+        @Test
+        @DisplayName("TC-05: Сбой Kafka -> аварийная остановка, состояние НЕ сохраняется")
+        void execute_whenKafkaFails_shouldAbortAndNotSaveState() {
+            // Arrange
+            when(mockJobStateRepository.findState(any(), any(), any())).thenReturn(Optional.empty());
+
+            PaginatedUserIdsResponse page = new PaginatedUserIdsResponse(List.of(1L, 2L), new PageInfo(true, "next_cursor"));
+            when(mockUserIdsFetcherClient.fetchUserIds(isNull(), eq(PAGE_SIZE))).thenReturn(page);
+
+            // Kafka падает для одного из сообщений
+            when(mockKafkaTemplate.send(any(), any()))
+                    .thenReturn(CompletableFuture.completedFuture(mock(SendResult.class))) // Успех для 1L
+                    .thenReturn(CompletableFuture.failedFuture(new RuntimeException("Kafka down"))); // Провал для 2L
+
+            // Act
+            job.execute(REPORT_DATE);
+
+            // Assert
+            // 1. Метрика сбоя отправки
+            verify(mockMetrics).incrementCounter(eq(Metric.JOB_KAFKA_SEND_FAILURE), any(Tags.class));
+
+            // 2. Метрика сбоя джобы (в catch блоке)
+            verify(mockMetrics).incrementCounter(eq(Metric.JOB_RUN_FAILURE), any(Tags.class));
+
+            // 3. Самое важное: saveState НЕ должен быть вызван. Никакого прогресса не фиксируем.
+            verify(mockJobStateRepository, never()).saveState(any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("TC-06: Сбой API -> джоба падает, состояние не меняется")
+        void execute_whenApiFails_shouldAbort() {
+            when(mockJobStateRepository.findState(any(), any(), any())).thenReturn(Optional.empty());
+            when(mockUserIdsFetcherClient.fetchUserIds(any(), anyInt())).thenThrow(new RuntimeException("API error"));
+
+            job.execute(REPORT_DATE);
+
+            verify(mockMetrics).incrementCounter(eq(Metric.JOB_RUN_FAILURE), any(Tags.class));
+            verify(mockJobStateRepository, never()).saveState(any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("TC-07: Потеря блокировки -> джоба падает")
+        void execute_whenLockLost_shouldAbort() {
+            when(mockJobStateRepository.findState(any(), any(), any())).thenReturn(Optional.empty());
+
+            // Мокаем статик, чтобы выбросить исключение при попытке продлить лок
+            lockExtenderMockedStatic.when(() -> LockExtender.extendActiveLock(any(), any()))
+                    .thenThrow(new LockExtender.NoActiveLockException());
+
+            job.execute(REPORT_DATE);
+
+            verify(mockUserIdsFetcherClient, never()).fetchUserIds(any(), anyInt()); // До фетча не дошли
+            verify(mockMetrics).incrementCounter(eq(Metric.JOB_RUN_FAILURE), any(Tags.class));
+        }
+    }
+}


### PR DESCRIPTION
Этот PR реализует основную бизнес-логику для джобы-продюсера (`SCHED-05`), которая отвечает за выборку ID пользователей и публикацию событий в Kafka. Реализация основана на архитектуре, заложенной в `refactor/scheduler-foundation-and-structure` и `feature/metrics-foundation`.

**Что сделано:**

1.  **`DailyTaskReportProducerJob`:**
    *   Реализован основной метод `execute`, который управляет жизненным циклом джобы.
    *   **Отказоустойчивость:** Реализована логика возобновления (`resume`) при старте со статусом `IN_PROGRESS` и пропуска при `PUBLISHED`.
    *   **Надежность:** При сбое отправки сообщений в Kafka, джоба аварийно завершается **без сохранения курсора**, что гарантирует повторную обработку пачки при следующем запуске (семантика `at-least-once`).
    *   **Долгоживущие задачи:** Внедрен механизм продления блокировки `ShedLock` (`LockExtender`) внутри цикла обработки страниц, чтобы предотвратить потерю лока при длительной работе.
    *   **Наблюдаемость:** Интегрированы метрики для отслеживания длительности выполнения (`JOB_RUN_DURATION`), количества опубликованных событий и ошибок. MDC-контекст (`job.run.id` и др.) устанавливается на все время выполнения.

2.  **`DailyTaskReportJobTrigger`:**
    *   Создан "тонкий" триггер, который по CRON-расписанию запускает `DailyTaskReportProducerJob` под распределенной блокировкой `ShedLock`.

3.  **`DailyReportJobConfiguration`:**
    *   Все бины, относящиеся к этой джобе (триггер, сама джоба), вынесены в отдельный `@Configuration` класс.
    *   Конфигурация защищена аннотацией `@ConditionalOnProperty`, что позволяет полностью включать или отключать всю джобу одним флагом в `application.yml`.

**Тестирование:**
*   `DailyTaskReportJobTriggerTest`: Юнит-тесты проверяют, что триггер корректно конфигурирует и запускает `LockingTaskExecutor`.
*   `DailyTaskReportProducerJobIT` (Integration Test): Создан **интеграционный тест**, использующий **Testcontainers** (Redis, Kafka) и **WireMock** (для Backend API). Тест проверяет полный "happy path" сценарий:
    *   Запуск джобы.
    *   Взаимодействие с моком Backend API (с пагинацией).
    *   Публикация событий в тестовый топик Kafka.
    *   Корректное сохранение финального статуса `PUBLISHED` в Redis.

**Зачем это нужно:**
Этот PR является ключевым в реализации сервиса-планировщика. Он создает работающий механизм, который надежно и эффективно поставляет данные для дальнейшей обработки консьюмерами.

**Зависимости:**
*   Этот PR основан на ветке `feature/SCHED-05-part1-persistence`.