### PR TITLE
feat(email-sender): implement DLT/Retry dispatcher

### DIFF
--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/config/KafkaConfig.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/config/KafkaConfig.java
@@ -1,0 +1,29 @@
+package com.example.tasktracker.emailsender.config;
+
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+import java.util.Map;
+
+@Configuration
+@EnableKafka
+public class KafkaConfig {
+
+    @Bean("byteArrayProducerFactory")
+    public ProducerFactory<byte[], byte[]> producerFactory(KafkaProperties kafkaProperties) {
+        Map<String, Object> props = kafkaProperties.buildProducerProperties(null);
+        return new DefaultKafkaProducerFactory<>(props, new ByteArraySerializer(), new ByteArraySerializer());
+    }
+
+    @Bean("rawKafkaTemplate")
+    public KafkaTemplate<byte[], byte[]> kafkaTemplate(@Qualifier("byteArrayProducerFactory") ProducerFactory<byte[], byte[]> producerFactory) {
+        return new KafkaTemplate<>(producerFactory);
+    }
+}

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/config/PipelineConfig.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/config/PipelineConfig.java
@@ -1,10 +1,12 @@
 package com.example.tasktracker.emailsender.config;
 
 import com.example.tasktracker.emailsender.infra.RuntimeInstanceIdProvider;
+import com.example.tasktracker.emailsender.messaging.util.KafkaMetadataEnricher;
 import com.example.tasktracker.emailsender.pipeline.ChunkingExecutor;
 import com.example.tasktracker.emailsender.pipeline.assembler.BatchAssembler;
 import com.example.tasktracker.emailsender.pipeline.assembler.ValidatingBatchAssembler;
 import com.example.tasktracker.emailsender.pipeline.assembler.processor.*;
+import com.example.tasktracker.emailsender.pipeline.dispatch.DispatcherStep;
 import com.example.tasktracker.emailsender.pipeline.idempotency.IdempotencyGuard;
 import com.example.tasktracker.emailsender.pipeline.idempotency.RedisIdempotencyCommitter;
 import com.example.tasktracker.emailsender.pipeline.idempotency.RedisIdempotencyGuard;
@@ -21,6 +23,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.kafka.core.KafkaTemplate;
 
 import java.time.Clock;
 import java.util.List;
@@ -87,4 +90,13 @@ public class PipelineConfig {
     public ExecutorService virtualThreadExecutor() {
         return Executors.newVirtualThreadPerTaskExecutor();
     }
+
+    @Bean
+    public DispatcherStep dispatcherStep(
+            KafkaMetadataEnricher metadataEnricher,
+            @Qualifier("rawKafkaTemplate") KafkaTemplate<byte[], byte[]> kafkaTemplate,
+            EmailSenderProperties properties) {
+        return new DispatcherStep(metadataEnricher, kafkaTemplate, properties);
+    }
+
 }

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/messaging/util/KafkaMetadataEnricher.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/messaging/util/KafkaMetadataEnricher.java
@@ -1,0 +1,90 @@
+package com.example.tasktracker.emailsender.messaging.util;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Headers;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.kafka.support.KafkaUtils;
+import org.springframework.stereotype.Component;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+
+@Component
+@Slf4j
+public class KafkaMetadataEnricher {
+
+    private static final List<String> METADATA_KEYS = List.of(
+            KafkaHeaders.ORIGINAL_TOPIC,
+            KafkaHeaders.ORIGINAL_PARTITION,
+            KafkaHeaders.ORIGINAL_OFFSET,
+            KafkaHeaders.ORIGINAL_TIMESTAMP,
+            KafkaHeaders.ORIGINAL_TIMESTAMP_TYPE,
+            KafkaHeaders.DLT_ORIGINAL_CONSUMER_GROUP,
+            KafkaHeaders.EXCEPTION_FQCN,
+            KafkaHeaders.EXCEPTION_MESSAGE,
+            KafkaHeaders.EXCEPTION_STACKTRACE,
+            KafkaHeaders.EXCEPTION_CAUSE_FQCN
+    );
+
+
+    /**
+     * Обогащает заголовки информацией об оригинальном сообщении и причине отказа.
+     */
+    public void enrichWithFailureMetadata(Headers targetHeaders,
+                                          ConsumerRecord<byte[], byte[]> sourceRecord,
+                                          Throwable rejectCause) {
+        clearExistingMetadata(targetHeaders);
+        copySourceCoordinates(targetHeaders, sourceRecord);
+        injectErrorDetails(targetHeaders, rejectCause);
+    }
+
+    public void clearExistingMetadata(Headers headers) {
+        METADATA_KEYS.forEach(headers::remove);
+    }
+
+    /**
+     * Записывает координаты сообщения (Topic, Partition, Offset).
+     */
+    private void copySourceCoordinates(Headers headers, ConsumerRecord<byte[], byte[]> original) {
+        addHeader(headers, KafkaHeaders.ORIGINAL_TOPIC, original.topic());
+        addHeader(headers, KafkaHeaders.ORIGINAL_PARTITION, original.partition());
+        addHeader(headers, KafkaHeaders.ORIGINAL_OFFSET, original.offset());
+        addHeader(headers, KafkaHeaders.ORIGINAL_TIMESTAMP, original.timestamp());
+        addHeader(headers, KafkaHeaders.ORIGINAL_TIMESTAMP_TYPE, original.timestampType().name());
+
+        String groupId = KafkaUtils.getConsumerGroupId();
+        if (groupId != null) {
+            addHeader(headers, KafkaHeaders.DLT_ORIGINAL_CONSUMER_GROUP, groupId);
+        }
+    }
+
+    /**
+     * Записывает детали исключения для отладки.
+     */
+    private void injectErrorDetails(Headers headers, Throwable ex) {
+        if (ex == null) return;
+
+        addHeader(headers, KafkaHeaders.EXCEPTION_FQCN, ex.getClass().getName());
+        addHeader(headers, KafkaHeaders.EXCEPTION_MESSAGE, ex.getMessage());
+        addHeader(headers, KafkaHeaders.EXCEPTION_STACKTRACE, getStackTrace(ex));
+
+        Optional.ofNullable(ex.getCause())
+                .ifPresent(cause -> addHeader(headers, KafkaHeaders.EXCEPTION_CAUSE_FQCN, cause.getClass().getName()));
+    }
+
+    private void addHeader(Headers headers, String key, Object value) {
+        if (value != null) {
+            headers.add(key, String.valueOf(value).getBytes(StandardCharsets.UTF_8));
+        }
+    }
+
+    private String getStackTrace(Throwable t) {
+        StringWriter sw = new StringWriter();
+        t.printStackTrace(new PrintWriter(sw));
+        return sw.toString();
+    }
+}

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/pipeline/dispatch/BrokerUnavailableException.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/pipeline/dispatch/BrokerUnavailableException.java
@@ -1,0 +1,9 @@
+package com.example.tasktracker.emailsender.pipeline.dispatch;
+
+import com.example.tasktracker.emailsender.exception.infrastructure.InfrastructureException;
+
+public class BrokerUnavailableException extends InfrastructureException {
+    public BrokerUnavailableException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/pipeline/dispatch/DispatcherStep.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/pipeline/dispatch/DispatcherStep.java
@@ -1,0 +1,182 @@
+package com.example.tasktracker.emailsender.pipeline.dispatch;
+
+import com.example.tasktracker.emailsender.config.EmailSenderProperties;
+import com.example.tasktracker.emailsender.exception.FatalProcessingException;
+import com.example.tasktracker.emailsender.exception.infrastructure.InfrastructureException;
+import com.example.tasktracker.emailsender.exception.infrastructure.InfrastructureSuspendedException;
+import com.example.tasktracker.emailsender.messaging.util.KafkaMetadataEnricher;
+import com.example.tasktracker.emailsender.pipeline.model.PipelineBatch;
+import com.example.tasktracker.emailsender.pipeline.model.PipelineItem;
+import com.example.tasktracker.emailsender.pipeline.model.RejectReason;
+import com.example.tasktracker.emailsender.util.AsyncUtils;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.springframework.kafka.support.KafkaUtils.determineSendTimeout;
+
+@Slf4j
+public class DispatcherStep {
+    private final KafkaMetadataEnricher metadataEnricher;
+    private final KafkaTemplate<byte[], byte[]> kafkaTemplate;
+    private final Duration sendTimeout;
+    protected final String retryTopic;
+    protected final String dltTopicName;
+
+    public DispatcherStep(
+            KafkaMetadataEnricher metadataEnricher,
+            KafkaTemplate<byte[], byte[]> kafkaTemplate,
+            EmailSenderProperties properties
+    ) {
+        this.metadataEnricher = metadataEnricher;
+        this.kafkaTemplate = kafkaTemplate;
+        this.retryTopic = properties.getRetryTopic();
+        this.dltTopicName = properties.getDltTopic();
+
+        this.sendTimeout = determineSendTimeout(
+                kafkaTemplate.getProducerFactory().getConfigurationProperties(),
+                2000L,
+                5000L
+        );
+    }
+
+    /**
+     * Выполняет финальную маршрутизацию элементов батча на основе их терминальных статусов.
+     * <p>
+     * Метод работает по следующему алгоритму:
+     * 1. Валидация инвариантов: все элементы должны быть обработаны (не быть в статусе PENDING).
+     * 2. Проверка здоровья инфраструктуры: если хотя бы один элемент содержит {@link InfrastructureException},
+     * выбрасывается {@link InfrastructureSuspendedException} для перезапуска всего батча консьюмером.
+     * 3. Асинхронная отправка: элементы в статусах FAILED и RETRY отправляются в соответствующие топики Kafka.
+     * 4. Синхронизация: метод ожидает завершения всех сетевых операций в пределах {@code sendTimeout}.
+     * </p>
+     *
+     * @param batch Пакет обработанных элементов. Статус элементов SENT и SKIPPED игнорируется (ожидается Ack).
+     * @throws FatalProcessingException         если обнаружен элемент в статусе PENDING или неизвестном статусе.
+     * @throws InfrastructureSuspendedException если зафиксирован системный сбой (Circuit Breaker, Redis, и т.д.),
+     *                                          требующий остановки обработки и повтора всего батча.
+     * @throws BrokerUnavailableException       если возникла ошибка при попытке записи в Kafka (DLT/Retry топики).
+     */
+    public void dispatch(PipelineBatch batch) {
+        List<PipelineItem> pendingItems = batch.getPendingItems();
+        if (!pendingItems.isEmpty()) {
+            log.error("CRITICAL: Pipeline logic error. {} items are still PENDING in dispatcher.", pendingItems.size());
+            throw new FatalProcessingException(RejectReason.INTERNAL_ERROR,
+                    "Batch still contains items in PENDING state during dispatching",
+                    null);
+        }
+
+        List<PipelineItem> items = batch.items();
+
+        batch.items().stream()
+                .filter(PipelineItem::isFailed)
+                .forEach(this::checkInfrastructureHealth);
+
+        List<CompletableFuture<?>> routingFutures = new ArrayList<>();
+
+        for (var item : items) {
+            switch (item.getStatus()) {
+                case FAILED -> routingFutures.add(handleFatal(item));
+                case RETRY -> routingFutures.add(handleTransient(item));
+                case SKIPPED -> log.trace("Item [{}] skipped.", item.getCoordinates());
+                case SENT -> log.trace("Item [{}] successfully processed.", item.getCoordinates());
+                default -> throw new FatalProcessingException(RejectReason.INTERNAL_ERROR,
+                        "Unexpected value: " + item.getStatus(),
+                        null);
+            }
+        }
+
+        if (!routingFutures.isEmpty()) {
+            try {
+                CompletableFuture.allOf(routingFutures.toArray(new CompletableFuture[0]))
+                        .orTimeout(sendTimeout.toMillis(), TimeUnit.MILLISECONDS)
+                        .join();
+                log.info("Successfully routed {} problematic items (DLT/Retry)", routingFutures.size());
+            } catch (Exception e) {
+                routingFutures.forEach(f -> f.cancel(true));
+                log.warn("Failed to route items to DLT/Retry. Aborting.");
+                throw new BrokerUnavailableException("Failed to secure problematic items in Kafka", AsyncUtils.unwrap(e));
+            }
+        }
+    }
+
+    protected CompletableFuture<?> handleTransient(PipelineItem item) {
+        log.info("Sending item [{}] to RETRY topic. Reason: {}",
+                item.getCoordinates(), item.getRejectDescription());
+
+        ProducerRecord<byte[], byte[]> record = buildProducerRecord(retryTopic, item);
+        return doSend(record);
+    }
+
+    protected CompletableFuture<?> handleFatal(PipelineItem item) {
+        log.warn("Sending item [{}] to DLT. Reason: '{}'",
+                item.getCoordinates(), item.getRejectDescription());
+
+        ProducerRecord<byte[], byte[]> record = buildProducerRecord(dltTopicName, item);
+        return doSend(record);
+    }
+
+    protected ProducerRecord<byte[], byte[]> buildProducerRecord(String topic, PipelineItem item) {
+        ConsumerRecord<byte[], byte[]> orig = item.getOriginalRecord();
+        ProducerRecord<byte[], byte[]> record = new ProducerRecord<>(topic,
+                null,
+                orig.key(),
+                orig.value(),
+                new RecordHeaders(orig.headers()));
+
+        metadataEnricher.enrichWithFailureMetadata(record.headers(), orig, item.getRejectCause());
+        return record;
+    }
+
+    protected CompletableFuture<SendResult<byte[], byte[]>> doSend(ProducerRecord<byte[], byte[]> record) {
+        return kafkaTemplate.send(record)
+                .whenComplete((result, ex) -> {
+                    if (ex != null) {
+                        if (ex instanceof CancellationException) {
+                            log.debug("Routing task for key {} was cancelled (Batch Aborted).", decodeKey(record.key()));
+                            return;
+                        }
+
+                        Throwable cause = AsyncUtils.unwrap(ex);
+                        log.error("CRITICAL: Kafka routing failure! Topic: {}, Key: {}. Reason: {}",
+                                record.topic(),
+                                decodeKey(record.key()),
+                                cause.getMessage());
+                    } else {
+                        log.trace("Route to {} successful. Offset: {}",
+                                record.topic(), result.getRecordMetadata().offset());
+                    }
+                });
+    }
+
+    private void checkInfrastructureHealth(PipelineItem item) {
+        Throwable cause = item.getRejectCause();
+        if (cause == null) return;
+
+        Throwable root = cause;
+        while (root != null) {
+            if (root instanceof InfrastructureException infra) {
+                log.warn("INFRASTRUCTURE FAILURE DETECTED at [{}]. Reason: '{}'. Triggering whole batch retry.",
+                        item.getCoordinates(), infra.getMessage());
+                throw new InfrastructureSuspendedException("Infrastructure failure: " + infra.getMessage(), infra);
+            }
+            root = root.getCause();
+        }
+    }
+
+    private String decodeKey(byte[] key) {
+        if (key == null) return "null";
+        return new String(key, StandardCharsets.UTF_8);
+    }
+}


### PR DESCRIPTION
Этот PR внедряет этап конвейера, отвечающий за маршрутизацию результатов обработки в соответствующие топики Kafka (DLT для фатальных ошибок и Retry для временных сбоев) и гарантирует, что оффсеты в Kafka будут закомичены только после успешного сохранения всех проблемных сообщений:

1. **Изоляция Poison Pill**:
   Если в топик упадет сообщение с кривым JSON или несуществующим ID шаблона, оно не должно блокировать всю очередь (постоянно падая и заставляя Kafka делать ретрай). Такие письма помечаются как `FAILED` и улетают в DLT. Очередь едет дальше.
2. **Безопасная пересылка**:
   При отправке в DLT/Retry мы не используем JSON-сериализатор. Мы перекладываем сырые массивы байтов (`byte[]`). Это гарантирует, что даже абсолютно нечитаемый мусор будет безопасно сохранен для ретроспективного анализа.
3. **Защита от массовых инцидентов**:
   Перед отправкой каждого письма в DLT/Retry мы проверяем его `RejectCause`. Если в корне лежит `InfrastructureException` (например, упал Redis или отвалился SMTP-провайдер), мы **прерываем весь процесс маршрутизации** и бросаем `InfrastructureSuspendedException`. Это заставит Kafka-консьюмер остановиться и не перекладывать миллион писем в Retry-топик.
4. **Удобство эксплуатации**:
   В топики DLT сообщения приходят обогащенными. В заголовках лежат оригинальный топик, оффсет, имя класса ошибки и полный Stack Trace.
   
### **Known Trade-offs**
*    При обнаружении сбоя даже внешней инфраструктуры весь батч уходит на полный ретрай.
*    Стэктрейсы записываются в заголовки полностью. Это несет риск превышения `message.max.bytes` брокера, однако данный риск признан приемлемым ради полноты диагностической информации.