### PR TITLE
feat(email-sender): initialize observability core and OTLP export

### DIFF
--- a/task-tracker-email-sender/pom.xml
+++ b/task-tracker-email-sender/pom.xml
@@ -100,6 +100,36 @@
         </dependency>
 
         <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-java21</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-otlp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-tracing-bridge-otel</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-logback-appender-1.0</artifactId>
+            <version>2.9.0-alpha</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.codehaus.janino</groupId>
+            <artifactId>janino</artifactId>
+            <version>3.1.12</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/config/AppProperties.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/config/AppProperties.java
@@ -20,4 +20,11 @@ public class AppProperties {
      */
     @NotBlank
     private String instanceId;
+
+    private ObservationProperties observability = new ObservationProperties();
+
+    @Getter @Setter
+    public static class ObservationProperties {
+        private boolean enabled = true;
+    }
 }

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/config/PipelineConfig.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/config/PipelineConfig.java
@@ -2,6 +2,7 @@ package com.example.tasktracker.emailsender.config;
 
 import com.example.tasktracker.emailsender.infra.RuntimeInstanceIdProvider;
 import com.example.tasktracker.emailsender.messaging.util.KafkaMetadataEnricher;
+import com.example.tasktracker.emailsender.o11y.observation.annotation.ObservedExecutor;
 import com.example.tasktracker.emailsender.pipeline.ChunkingExecutor;
 import com.example.tasktracker.emailsender.pipeline.EmailProcessor;
 import com.example.tasktracker.emailsender.pipeline.assembler.BatchAssembler;
@@ -100,6 +101,7 @@ public class PipelineConfig {
     }
 
     @Bean("virtualThreadExecutor")
+    @ObservedExecutor(value = "email.sender.vthread.executor", metrics = false)
     public ExecutorService virtualThreadExecutor() {
         return Executors.newVirtualThreadPerTaskExecutor();
     }

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/config/ExecutorObservabilityEnabler.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/config/ExecutorObservabilityEnabler.java
@@ -1,0 +1,70 @@
+package com.example.tasktracker.emailsender.o11y.config;
+
+import com.example.tasktracker.emailsender.o11y.observation.annotation.ObservedExecutor;
+import io.micrometer.context.ContextExecutorService;
+import io.micrometer.context.ContextSnapshotFactory;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.type.MethodMetadata;
+
+import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+
+@Configuration
+@ConditionalOnProperty(value = "app.observability.enabled", havingValue = "true", matchIfMissing = true)
+@RequiredArgsConstructor
+public class ExecutorObservabilityEnabler implements BeanPostProcessor {
+
+    private final ObjectProvider<MeterRegistry> meterRegistryProvider;
+    private final ObjectProvider<ContextSnapshotFactory> contextSnapshotFactoryProvider;
+
+    private final ConfigurableListableBeanFactory beanFactory;
+
+    @Override
+    public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+        if (bean instanceof ExecutorService executor) {
+            ObservedExecutor ann = findAnnotation(beanName);
+            if (ann != null) {
+                if (ann.propagation()) {
+                    executor = ContextExecutorService.wrap(executor,
+                            Objects.requireNonNull(contextSnapshotFactoryProvider.getIfAvailable()));
+                }
+                if (ann.metrics()) {
+                    executor = ExecutorServiceMetrics.monitor(Objects.requireNonNull(meterRegistryProvider.getIfAvailable()),
+                            executor, ann.value(), Tags.empty());
+                }
+                return executor;
+            }
+        }
+        return bean;
+    }
+
+    private ObservedExecutor findAnnotation(String beanName) {
+        if (!beanFactory.containsBeanDefinition(beanName)) {
+            return null;
+        }
+        BeanDefinition bd = beanFactory.getMergedBeanDefinition(beanName);
+
+        if (bd instanceof AnnotatedBeanDefinition abd) {
+            MethodMetadata factoryMethodMetadata = abd.getFactoryMethodMetadata();
+            if (factoryMethodMetadata != null) {
+                var mergedAnn = factoryMethodMetadata.getAnnotations().get(ObservedExecutor.class);
+                if (mergedAnn.isPresent()) {
+                    return mergedAnn.synthesize();
+                }
+            }
+        }
+
+        return beanFactory.findAnnotationOnBean(beanName, ObservedExecutor.class);
+    }
+}

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/config/ObservabilityCoreConfig.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/config/ObservabilityCoreConfig.java
@@ -1,0 +1,89 @@
+package com.example.tasktracker.emailsender.o11y.config;
+
+import com.example.tasktracker.emailsender.o11y.observation.handler.LinkingPropagatingTracingObservationHandler;
+import io.micrometer.context.ContextRegistry;
+import io.micrometer.context.ContextSnapshotFactory;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.java21.instrument.binder.jdk.VirtualThreadMetrics;
+import io.micrometer.observation.Observation;
+import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.handler.DefaultTracingObservationHandler;
+import io.micrometer.tracing.handler.PropagatingReceiverTracingObservationHandler;
+import io.micrometer.tracing.handler.PropagatingSenderTracingObservationHandler;
+import io.micrometer.tracing.propagation.Propagator;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.instrumentation.logback.appender.v1_0.OpenTelemetryAppender;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.boot.actuate.autoconfigure.tracing.MicrometerTracingAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.event.EventListener;
+import org.springframework.core.annotation.Order;
+
+@Configuration
+@ConditionalOnProperty(value = "app.observability.enabled", havingValue = "true", matchIfMissing = true)
+@Slf4j
+public class ObservabilityCoreConfig {
+
+    @Bean
+    public ContextSnapshotFactory contextSnapshotFactory() {
+        return ContextSnapshotFactory.builder()
+                .contextRegistry(ContextRegistry.getInstance())
+                .clearMissing(true)
+                .build();
+    }
+
+    @Bean
+    public VirtualThreadMetrics virtualThreadMetrics(MeterRegistry registry) {
+        VirtualThreadMetrics virtualThreadMetrics = new VirtualThreadMetrics();
+        virtualThreadMetrics.bindTo(registry);
+        return virtualThreadMetrics;
+    }
+
+    @Bean
+    public InitializingBean otelLoggingInitializer(OpenTelemetry openTelemetry) {
+        return () -> OpenTelemetryAppender.install(openTelemetry);
+    }
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void checkJvmAccess() {
+        Module javaBase = Object.class.getModule();
+        Module appModule = this.getClass().getModule();
+
+        boolean isOpen = javaBase.isOpen("java.util.concurrent", appModule);
+
+        if (!isOpen) {
+            log.warn("O11Y: JVM access to 'java.util.concurrent' is CLOSED. Virtual Thread metrics will be limited. " +
+                    "Consider adding '--add-opens java.base/java.util.concurrent=ALL-UNNAMED' to JVM arguments.");
+        }
+    }
+
+    @Bean
+    @Order(MicrometerTracingAutoConfiguration.DEFAULT_TRACING_OBSERVATION_HANDLER_ORDER)
+    public DefaultTracingObservationHandler defaultTracingObservationHandler(Tracer tracer, Propagator propagator) {
+        return new LinkingPropagatingTracingObservationHandler(tracer, propagator);
+    }
+
+    @Bean
+    public PropagatingSenderTracingObservationHandler<?> disabledSenderHandler(Tracer tracer, Propagator propagator) {
+        return new PropagatingSenderTracingObservationHandler<>(tracer, propagator) {
+            @Override
+            public boolean supportsContext(Observation.Context context) {
+                return false;
+            }
+        };
+    }
+
+    @Bean
+    public PropagatingReceiverTracingObservationHandler<?> disabledReceiverHandler(Tracer tracer, Propagator propagator) {
+        return new PropagatingReceiverTracingObservationHandler<>(tracer, propagator) {
+            @Override
+            public boolean supportsContext(Observation.Context context) {
+                return false;
+            }
+        };
+    }
+}

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/annotation/ObservedExecutor.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/annotation/ObservedExecutor.java
@@ -1,0 +1,33 @@
+package com.example.tasktracker.emailsender.o11y.observation.annotation;
+
+import java.lang.annotation.*;
+
+/**
+ * Маркер для декларативной настройки обсервабилити {@link java.util.concurrent.ExecutorService}.
+ * Позволяет управлять регистрацией метрик Micrometer и механизмами проброса контекста (Tracing, MDC).
+ *
+ * @see com.example.tasktracker.emailsender.o11y.config.ExecutorObservabilityEnabler
+ */
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface ObservedExecutor {
+
+    /**
+     * Идентификатор экзекьютора. Используется как значение тега 'name' в метриках.
+     */
+    String value();
+
+    /**
+     * Флаг регистрации стандартных метрик {@link io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics}.
+     * Включает сбор данных об активных потоках, размере очереди и выполненных задачах.
+     */
+    boolean metrics() default true;
+
+    /**
+     * Флаг активации {@link io.micrometer.context.ContextExecutorService}.
+     * Обеспечивает захват (snapshot) текущего контекста (TraceId, MDC, Security)
+     * и его восстановление внутри потока выполнения задачи.
+     */
+    boolean propagation() default true;
+}

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/context/BatchContext.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/context/BatchContext.java
@@ -1,0 +1,5 @@
+package com.example.tasktracker.emailsender.o11y.observation.context;
+
+public interface BatchContext {
+    int getBatchSize();
+}

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/context/DetachedContext.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/context/DetachedContext.java
@@ -1,0 +1,14 @@
+package com.example.tasktracker.emailsender.o11y.observation.context;
+
+import io.micrometer.tracing.TraceContext;
+
+/**
+ * Указывает, что удаленный родитель (например, RECEIVE в Kafka) из заголовков может стать Link-ом,
+ * а не Parent-ом, чтобы избежать "бесконечных" трейсов.
+ */
+public interface DetachedContext {
+
+    TraceContext getRemoteParentLink();
+
+    void setRemoteParentLink(TraceContext context);
+}

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/convention/BaseO11yConvention.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/convention/BaseO11yConvention.java
@@ -1,0 +1,20 @@
+package com.example.tasktracker.emailsender.o11y.observation.convention;
+
+import io.micrometer.common.KeyValues;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationConvention;
+import io.opentelemetry.semconv.ErrorAttributes;
+
+public abstract class BaseO11yConvention<T extends Observation.Context> implements ObservationConvention<T> {
+    @Override
+    public KeyValues getLowCardinalityKeyValues(T context) {
+        if (context.getError() != null) {
+            String errorType = context.getError().getClass().getCanonicalName();
+            if (errorType == null) {
+                errorType = context.getError().getClass().getName();
+            }
+            return KeyValues.of(ErrorAttributes.ERROR_TYPE.getKey(), errorType);
+        }
+        return KeyValues.empty();
+    }
+}

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/handler/LinkingPropagatingTracingObservationHandler.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/handler/LinkingPropagatingTracingObservationHandler.java
@@ -1,0 +1,101 @@
+package com.example.tasktracker.emailsender.o11y.observation.handler;
+
+import com.example.tasktracker.emailsender.o11y.observation.context.DetachedContext;
+import io.micrometer.common.util.StringUtils;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.transport.ReceiverContext;
+import io.micrometer.observation.transport.SenderContext;
+import io.micrometer.tracing.Link;
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.handler.DefaultTracingObservationHandler;
+import io.micrometer.tracing.propagation.Propagator;
+import lombok.extern.slf4j.Slf4j;
+
+import java.net.URI;
+
+/**
+ * Хендлер, который умеет добавлять Links при создании Span.
+ */
+@Slf4j
+public class LinkingPropagatingTracingObservationHandler extends DefaultTracingObservationHandler {
+
+    private final Propagator propagator;
+
+    public LinkingPropagatingTracingObservationHandler(Tracer tracer, Propagator propagator) {
+        super(tracer);
+        this.propagator = propagator;
+    }
+
+    @Override
+    public void onStart(Observation.Context context) {
+        Span.Builder builder;
+
+        if (context instanceof ReceiverContext<?> rc) {
+            if (context instanceof DetachedContext) {
+                builder = getTracer().spanBuilder();
+            } else {
+                builder = extract(rc);
+            }
+        } else {
+            builder = getTracer().spanBuilder();
+            Span localParent = getParentSpan(context);
+            if (localParent != null) {
+                builder.setParent(localParent.context());
+            }
+        }
+
+        if (context instanceof DetachedContext dc && dc.getRemoteParentLink() != null) {
+            builder.addLink(new Link(dc.getRemoteParentLink()));
+        }
+
+        if (context instanceof ReceiverContext<?> rc) {
+            builder.kind(Span.Kind.valueOf(rc.getKind().name()));
+            builder.remoteServiceName(rc.getRemoteServiceName());
+            setRemoteCoords(rc.getRemoteServiceAddress(), builder);
+        } else if (context instanceof SenderContext<?> sc) {
+            builder.kind(Span.Kind.valueOf(sc.getKind().name()));
+            builder.remoteServiceName(sc.getRemoteServiceName());
+            setRemoteCoords(sc.getRemoteServiceAddress(), builder);
+        }
+
+        Span span = builder.start();
+        getTracingContext(context).setSpan(span);
+
+        if (context instanceof SenderContext<?> sc && sc.getCarrier() != null) {
+            inject(span, sc);
+        }
+    }
+
+    @Override
+    public String getSpanName(Observation.Context context) {
+        if (StringUtils.isNotBlank(context.getContextualName())) {
+            return context.getContextualName();
+        }
+        return context.getName();
+    }
+
+    void setRemoteCoords(String address, Span.Builder builder) {
+        if (address != null) {
+            try {
+                URI uri = URI.create(address);
+                builder.remoteIpAndPort(uri.getHost(), uri.getPort());
+            } catch (Exception ex) {
+                log.warn("Exception [{}], occurred while trying to parse the uri [{}] to host and port.", ex,
+                        address);
+            }
+        }
+    }
+
+    private <C> Span.Builder extract(ReceiverContext<C> rc) {
+        C carrier = rc.getCarrier();
+        var getter = rc.getGetter();
+        return this.propagator.extract(carrier, getter::get);
+    }
+
+    private <C> void inject(Span span, SenderContext<C> sc) {
+        C carrier = sc.getCarrier();
+        var setter = sc.getSetter();
+        this.propagator.inject(span.context(), carrier, setter::set);
+    }
+}

--- a/task-tracker-email-sender/src/main/resources/application-ci.yml
+++ b/task-tracker-email-sender/src/main/resources/application-ci.yml
@@ -8,6 +8,22 @@ spring:
   kafka:
     bootstrap-servers: overrideItLocal
 
+app:
+  observability:
+    enabled: true
+
+management:
+  defaults:
+    metrics:
+      export:
+        enabled: false
+  tracing:
+    enabled: false
+  logging:
+    export:
+      enabled: false
+
+
 logging:
   level:
     root: warn

--- a/task-tracker-email-sender/src/main/resources/application.yml
+++ b/task-tracker-email-sender/src/main/resources/application.yml
@@ -44,3 +44,37 @@ spring:
         heartbeat.interval.ms: 10000
         max.poll.interval.ms: 300000
       max-poll-records: ${app.email.reliability.budget.command-intake-batch-size}
+
+management:
+  opentelemetry:
+    resource-attributes:
+      service.instance.id: ${APP_INSTANCE_ID}
+      service.name: ${spring.application.name}
+  tracing:
+    enabled: true
+    sampling:
+      probability: 1.0
+    baggage:
+      correlation:
+        fields: ["correlation_id"]
+      remote-fields: ["correlation_id"]
+      tag-fields: ["correlation_id"]
+
+  otlp:
+    metrics:
+      export:
+        enabled: true
+        url: http://otel-collector:4318/v1/metrics
+    logging:
+      export:
+        enabled: true
+      endpoint: http://otel-collector:4318/v1/logs
+    tracing:
+      export:
+        enabled: true
+      endpoint: http://otel-collector:4318/v1/traces
+
+logging:
+  structured:
+    format:
+      console:

--- a/task-tracker-email-sender/src/main/resources/logback-spring.xml
+++ b/task-tracker-email-sender/src/main/resources/logback-spring.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <include resource="org/springframework/boot/logging/logback/defaults.xml" />
+    <property name="CONSOLE_LOG_PATTERN" value="%clr(%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd'T'HH:mm:ss.SSSXXX}}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p}){} %clr(${PID:-}){magenta} %clr(--- %esb(){APPLICATION_NAME}%esb{APPLICATION_GROUP}[%t] ${LOG_CORRELATION_PATTERN:-}){faint}%clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}"/>
+
+    <if condition='property("CONSOLE_LOG_STRUCTURED_FORMAT").length() > 0'> <!-- Если Спринг прокинул формат (ecs и т.д.) -->
+        <then>
+            <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+                <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+                    <level>${CONSOLE_LOG_THRESHOLD}</level>
+                </filter>
+                <encoder class="org.springframework.boot.logging.logback.StructuredLogEncoder">
+                    <format>${CONSOLE_LOG_STRUCTURED_FORMAT}</format>
+                    <charset>${CONSOLE_LOG_CHARSET}</charset>
+                </encoder>
+            </appender>
+        </then>
+        <else>
+            <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+                <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+                    <level>${CONSOLE_LOG_THRESHOLD}</level>
+                </filter>
+                <encoder>
+                    <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+                    <charset>${CONSOLE_LOG_CHARSET}</charset>
+                </encoder>
+            </appender>
+        </else>
+    </if>
+
+    <appender name="OTEL"
+              class="io.opentelemetry.instrumentation.logback.appender.v1_0.OpenTelemetryAppender">
+        <captureExperimentalAttributes>true</captureExperimentalAttributes>
+        <captureMdcAttributes>*</captureMdcAttributes>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="OTEL"/>
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+</configuration>


### PR DESCRIPTION
Этот PR активирует полноценный стек обсервабилити (Micrometer + OpenTelemetry) и превращает сервис в прозрачную систему. Мы внедряем базу для сбора и экспорта «трех столпов» телеметрии (Metrics, Traces, Logs) через унифицированный протокол OTLP, обеспечивая при этом строгое соответствие спецификации OpenTelemetry для асинхронных коммуникаций:

1.  **Активация телеметрии**:
    Мы подключаем ядро Micrometer и мост к OpenTelemetry.

2.  **Соответствие OTel Spec**:
    Стандартная реализация Micrometer нарушает семантику OpenTelemetry для систем обмена сообщениями, создавая бесконечные Parent-Child цепочки. 
    *   Мы внедрили **`LinkingPropagatingTracingObservationHandler`**, который заменяет жесткое наследование на механизм **Span Links**. 
    *   Это позволяет отслеживать путь сообщения через всю систему, не раздувая контекст одного трейса и предотвращая «Trace Explosion» в высоконагруженных очередях.

3.  **Мониторинг Java 21 (Virtual Threads)**:
    Поскольку архитектура полагается на виртуальные потоки, внедрен специфичный мониторинг через `VirtualThreadMetrics`. Это дает возможность отслеживать thread pinning и динамику планировщика JVM, что критично для стабильности асинхронного сендера.

4.  **Декларативное управление**:
    Введена аннотация **`@ObservedExecutor`** и соответствующий `BeanPostProcessor`. Для включения метрик и проброса контекста (TraceID, MDC) в любой `ExecutorService` достаточно одной аннотации, без ручного написания оберток в конфигурации.

5.  **Единый канал экспорта (OTLP & Structured Logging)**:
    *   Весь экспорт телеметрии (метрик, трейсов и логов) унифицирован и направлен в **OTel Collector** по протоколу OTLP.
    *   Логи стали частью OTel-пайплайна (через `OpenTelemetryAppender`), что позволяет коррелировать их с трейсами.
    *   Добавлена поддержка **Structured Logging**, позволяющая динамически переключаться между человекочитаемым форматом для разработки и машиночитаемым (ECS/JSON) для продакшена.