### PR TITLE
feat(email-sender): implement Kafka observability and trace isolation

### DIFF
--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/config/AppProperties.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/config/AppProperties.java
@@ -26,5 +26,6 @@ public class AppProperties {
     @Getter @Setter
     public static class ObservationProperties {
         private boolean enabled = true;
+        private boolean captureMessageSizes = false;
     }
 }

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/config/PipelineRetryConfig.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/config/PipelineRetryConfig.java
@@ -3,10 +3,16 @@ package com.example.tasktracker.emailsender.config;
 import com.example.tasktracker.emailsender.exception.RetryableProcessingException;
 import com.example.tasktracker.emailsender.exception.infrastructure.InfrastructureException;
 import com.example.tasktracker.emailsender.exception.infrastructure.InfrastructureSuspendedException;
+import com.example.tasktracker.emailsender.messaging.util.KafkaMetadataEnricher;
+import com.example.tasktracker.emailsender.pipeline.model.RejectReason;
+import lombok.RequiredArgsConstructor;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.NestedExceptionUtils;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.retrytopic.DeadLetterPublishingRecovererFactory;
 import org.springframework.kafka.retrytopic.RetryTopicConfiguration;
 import org.springframework.kafka.retrytopic.RetryTopicConfigurationBuilder;
 import org.springframework.kafka.retrytopic.RetryTopicConfigurationSupport;
@@ -15,9 +21,37 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.util.backoff.FixedBackOff;
 
 import java.time.Duration;
+import java.util.function.Consumer;
 
 @Configuration
+@RequiredArgsConstructor
 public class PipelineRetryConfig extends RetryTopicConfigurationSupport {
+    private final KafkaMetadataEnricher kafkaMetadataEnricher;
+
+    /**
+     * Данная функция намеренно мутирует объект заголовков оригинального {@code ConsumerRecord} перед отправкой.
+     * <p>
+     * <b>Это пока безопасно:</b>
+     * 1. Основной цикл обработки письма к этому моменту уже завершен (с ошибкой).
+     * 2. Удаляемые заголовки являются сугубо техническими/диагностическими и не влияют
+     *    на бизнес-логику или целостность данных.
+     * 3. В случае Nack и полного перечитывания, брокер выдаст "чистый" рекорд без мутаций.
+     */
+    @Override
+    protected Consumer<DeadLetterPublishingRecovererFactory> configureDeadLetterPublishingContainerFactory() {
+        return dlprf -> dlprf.setHeadersFunction((record, e) -> {
+            kafkaMetadataEnricher.clearRejectionDetails(record.headers());
+            Throwable thr = NestedExceptionUtils.getMostSpecificCause(e);
+            if (thr instanceof RetryableProcessingException re &&
+                    re.getRejectReason() != null &&
+                    re.getRejectReason() != RejectReason.NONE) {
+                RecordHeaders headers = new RecordHeaders();
+                kafkaMetadataEnricher.injectRejectionDetails(headers,re.getRejectReason(),re.getMessage());
+                return headers;
+            }
+            return null;
+        });
+    }
 
     @Override
     protected void configureBlockingRetries(BlockingRetriesConfigurer blockingRetries) {

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/messaging/util/KafkaHeaderReader.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/messaging/util/KafkaHeaderReader.java
@@ -2,14 +2,25 @@ package com.example.tasktracker.emailsender.messaging.util;
 
 import lombok.experimental.UtilityClass;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.header.Header;
+
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 @UtilityClass
 public class KafkaHeaderReader {
-    public static Optional<String> readString(ConsumerRecord<?, ?> record, String headerName) {
+    public static Optional<String> readAsString(ConsumerRecord<?, ?> record, String headerName) {
         Header header = record.headers().lastHeader(headerName);
+        return getValue(header);
+    }
+
+    public static Optional<String> readAsString(ProducerRecord<?, ?> record, String headerName) {
+        Header header = record.headers().lastHeader(headerName);
+        return getValue(header);
+    }
+
+    private static Optional<String> getValue(Header header) {
         if (header == null || header.value() == null) {
             return Optional.empty();
         }

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/messaging/util/KafkaMetadataEnricher.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/messaging/util/KafkaMetadataEnricher.java
@@ -2,6 +2,7 @@ package com.example.tasktracker.emailsender.messaging.util;
 
 import com.example.tasktracker.emailsender.api.messaging.MessagingHeaders;
 import com.example.tasktracker.emailsender.pipeline.model.PipelineItem;
+import com.example.tasktracker.emailsender.pipeline.model.RejectReason;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -20,17 +21,24 @@ import java.util.Optional;
 @Slf4j
 public class KafkaMetadataEnricher {
 
-    private static final List<String> METADATA_KEYS = List.of(
+    private static final List<String> COORDINATE_KEYS = List.of(
             KafkaHeaders.ORIGINAL_TOPIC,
             KafkaHeaders.ORIGINAL_PARTITION,
             KafkaHeaders.ORIGINAL_OFFSET,
             KafkaHeaders.ORIGINAL_TIMESTAMP,
             KafkaHeaders.ORIGINAL_TIMESTAMP_TYPE,
-            KafkaHeaders.DLT_ORIGINAL_CONSUMER_GROUP,
+            KafkaHeaders.DLT_ORIGINAL_CONSUMER_GROUP
+    );
+
+    private static final List<String> SPRING_ERROR_KEYS = List.of(
             KafkaHeaders.EXCEPTION_FQCN,
             KafkaHeaders.EXCEPTION_MESSAGE,
             KafkaHeaders.EXCEPTION_STACKTRACE,
-            KafkaHeaders.EXCEPTION_CAUSE_FQCN,
+            KafkaHeaders.EXCEPTION_CAUSE_FQCN
+    );
+
+    private static final List<String> REJECT_DETAILS_KEYS = List.of(
+            MessagingHeaders.X_REJECT_REASON,
             MessagingHeaders.X_REJECT_DESCRIPTION
     );
 
@@ -47,7 +55,22 @@ public class KafkaMetadataEnricher {
     }
 
     public void clearExistingMetadata(@NonNull Headers headers) {
-        METADATA_KEYS.forEach(headers::remove);
+        clearHeaders(headers, COORDINATE_KEYS);
+        clearHeaders(headers, SPRING_ERROR_KEYS);
+        clearHeaders(headers, REJECT_DETAILS_KEYS);
+    }
+
+    public void injectRejectionDetails(@NonNull Headers headers, RejectReason reason, String description) {
+        addHeader(headers, MessagingHeaders.X_REJECT_REASON, reason);
+        addHeader(headers, MessagingHeaders.X_REJECT_DESCRIPTION, description);
+    }
+
+    public void clearRejectionDetails(@NonNull Headers headers) {
+        clearHeaders(headers, REJECT_DETAILS_KEYS);
+    }
+
+    private void clearHeaders(Headers headers, List<String> keys) {
+        keys.forEach(headers::remove);
     }
 
     /**
@@ -80,10 +103,10 @@ public class KafkaMetadataEnricher {
                     .ifPresent(cause -> addHeader(headers, KafkaHeaders.EXCEPTION_CAUSE_FQCN, cause.getClass().getName()));
         }
 
-        addHeader(headers, MessagingHeaders.X_REJECT_DESCRIPTION, failureStage.rejectDescription());
+        injectRejectionDetails(headers, failureStage.rejectReason(), failureStage.rejectDescription());
     }
 
-    private void addHeader(@NonNull Headers headers, String key, Object value) {
+    public void addHeader(@NonNull Headers headers, String key, Object value) {
         if (value != null) {
             headers.add(key, String.valueOf(value).getBytes(StandardCharsets.UTF_8));
         }

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/config/KafkaObservabilityEnhancer.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/config/KafkaObservabilityEnhancer.java
@@ -1,0 +1,75 @@
+package com.example.tasktracker.emailsender.o11y.config;
+
+import com.example.tasktracker.emailsender.o11y.kafka.ObservedKafkaTemplate;
+import com.example.tasktracker.emailsender.o11y.observation.context.KafkaContextFactory;
+import com.example.tasktracker.emailsender.o11y.observation.context.kafka.KafkaRecordPublishContext;
+import com.example.tasktracker.emailsender.o11y.observation.convention.KafkaPublishConvention;
+import io.micrometer.observation.ObservationRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.ResolvableType;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+
+@Configuration
+@ConditionalOnProperty(value = "app.observability.enabled", havingValue = "true", matchIfMissing = true)
+@RequiredArgsConstructor
+@Slf4j
+public class KafkaObservabilityEnhancer implements BeanPostProcessor {
+
+    private final ObjectProvider<ObservationRegistry> registry;
+    private final ObjectProvider<KafkaContextFactory> contextFactory;
+    private final ObjectProvider<KafkaPublishConvention<KafkaRecordPublishContext>> kafkaPublishConvention;
+    private final ConfigurableListableBeanFactory beanFactory;
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+
+        if (bean instanceof KafkaTemplate<?, ?> originTemplate && !(bean instanceof ObservedKafkaTemplate)) {
+
+            if (!beanFactory.containsBeanDefinition(beanName)) {
+                log.debug("O11Y: Skipping KafkaTemplate [{}] - no BeanDefinition found (manually registered?).", beanName);
+                return bean;
+            }
+
+            ResolvableType declaredType = beanFactory.getMergedBeanDefinition(beanName).getResolvableType();
+            ResolvableType templateType = declaredType.as(KafkaTemplate.class);
+            Class<?> keyType = templateType.resolveGeneric(0);
+            Class<?> valueType = templateType.resolveGeneric(1);
+
+            if (keyType == byte[].class && valueType == byte[].class) {
+                return wrapWithObserved((KafkaTemplate<byte[], byte[]>) originTemplate);
+            } else {
+                log.debug("O11Y: Skipping KafkaTemplate [{}] (incompatible types: {}/{}).", beanName, keyType, valueType);
+            }
+        }
+
+        if (bean instanceof ConcurrentKafkaListenerContainerFactory<?, ?> factory) {
+            factory.getContainerProperties().setObservationEnabled(false);
+            factory.getContainerProperties().setMicrometerEnabled(false);
+        }
+
+        return bean;
+    }
+
+    private ObservedKafkaTemplate wrapWithObserved(KafkaTemplate<byte[], byte[]> origin) {
+        ObservedKafkaTemplate observed = new ObservedKafkaTemplate(
+                origin.getProducerFactory(),
+                registry.getIfAvailable(),
+                contextFactory.getIfAvailable(),
+                kafkaPublishConvention.getIfAvailable()
+        );
+
+        observed.setDefaultTopic(origin.getDefaultTopic());
+        observed.setMessageConverter(origin.getMessageConverter());
+
+        return observed;
+    }
+}

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/config/ObservabilityCoreConfig.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/config/ObservabilityCoreConfig.java
@@ -1,6 +1,10 @@
 package com.example.tasktracker.emailsender.o11y.config;
 
+import com.example.tasktracker.emailsender.config.AppProperties;
+import com.example.tasktracker.emailsender.o11y.observation.context.KafkaContextFactory;
+import com.example.tasktracker.emailsender.o11y.observation.handler.KafkaMessagingMetricsHandler;
 import com.example.tasktracker.emailsender.o11y.observation.handler.LinkingPropagatingTracingObservationHandler;
+import com.example.tasktracker.emailsender.o11y.observation.util.KafkaPropertiesResolver;
 import io.micrometer.context.ContextRegistry;
 import io.micrometer.context.ContextSnapshotFactory;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -12,6 +16,7 @@ import io.micrometer.tracing.handler.PropagatingReceiverTracingObservationHandle
 import io.micrometer.tracing.handler.PropagatingSenderTracingObservationHandler;
 import io.micrometer.tracing.propagation.Propagator;
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.instrumentation.logback.appender.v1_0.OpenTelemetryAppender;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.InitializingBean;
@@ -85,5 +90,17 @@ public class ObservabilityCoreConfig {
                 return false;
             }
         };
+    }
+
+    @Bean
+    public KafkaContextFactory kafkaContextFactory(KafkaPropertiesResolver resolver,
+                                                   AppProperties appProperties,
+                                                   TextMapPropagator propagator) {
+        return new KafkaContextFactory(resolver, appProperties, propagator);
+    }
+
+    @Bean
+    public KafkaMessagingMetricsHandler<?> kafkaMessagingMetricsHandler(MeterRegistry meterRegistry) {
+        return new KafkaMessagingMetricsHandler<>(meterRegistry);
     }
 }

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/config/ObservationConfig.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/config/ObservationConfig.java
@@ -1,0 +1,33 @@
+package com.example.tasktracker.emailsender.o11y.config;
+
+import com.example.tasktracker.emailsender.o11y.observation.context.kafka.KafkaRecordPublishContext;
+import com.example.tasktracker.emailsender.o11y.observation.convention.KafkaProcessConvention;
+import com.example.tasktracker.emailsender.o11y.observation.convention.KafkaPublishConvention;
+import com.example.tasktracker.emailsender.o11y.observation.convention.KafkaReceiveConvention;
+import com.example.tasktracker.emailsender.o11y.observation.convention.KafkaRejectPublishConvention;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnProperty(value = "app.observability.enabled", havingValue = "true", matchIfMissing = true)
+public class ObservationConfig {
+
+    @Bean
+    public KafkaProcessConvention kafkaProcessConvention() {
+        return new KafkaProcessConvention();
+    }
+
+    @Bean
+    public KafkaPublishConvention<KafkaRecordPublishContext> kafkaPublishConvention(){return new KafkaPublishConvention<>();}
+
+    @Bean
+    public KafkaRejectPublishConvention kafkaRejectPublishConvention() {
+        return new KafkaRejectPublishConvention();
+    }
+
+    @Bean
+    public KafkaReceiveConvention<?> kafkaReceiveConvention() {
+        return new KafkaReceiveConvention<>();
+    }
+}

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/kafka/ObservedKafkaTemplate.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/kafka/ObservedKafkaTemplate.java
@@ -1,0 +1,121 @@
+package com.example.tasktracker.emailsender.o11y.kafka;
+
+import com.example.tasktracker.emailsender.o11y.observation.context.DetachedContext;
+import com.example.tasktracker.emailsender.o11y.observation.context.KafkaContextFactory;
+import com.example.tasktracker.emailsender.o11y.observation.context.kafka.KafkaRecordPublishContext;
+import com.example.tasktracker.emailsender.o11y.observation.convention.KafkaPublishConvention;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.messaging.Message;
+import org.springframework.util.Assert;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Реализация {@link KafkaTemplate}, обеспечивающая гранулярную обсервабилити
+ * в соответствии со спецификацией OpenTelemetry для систем обмена сообщениями.
+ * <p>
+ * 1. <b>Span Links вместо Parent-Child:</b> В отличие от стандартной инструментации
+ *    Spring Kafka, поддерживает концепцию {@link DetachedContext}. Это
+ *    позволяет использовать links вместо вложенности, предотвращая
+ *    "Trace Explosion" в длинных цепочках продюсер-консьюмер.
+ * 2. <b>Точность метрик (Post-ACK metadata):</b> Жизненный цикл наблюдения синхронизирован
+ *    с сетевыми коллбэками Kafka. Это гарантирует захват координат
+ *    сообщения (partition, offset) <b>после</b> подтверждения брокером, но <b>до</b>
+ *    фиксации метрик и закрытия спана.
+ * 3. <b>Контекстное разделение:</b> Автоматически выбирает тип контекста (Publish vs Reject)
+ *    на основе метаданных сообщения, что позволяет разделять телеметрию.
+ */
+public class ObservedKafkaTemplate extends KafkaTemplate<byte[], byte[]> {
+
+    private final ObservationRegistry registry;
+    private final KafkaContextFactory contextFactory;
+    private final KafkaPublishConvention<KafkaRecordPublishContext> kafkaPublishConvention;
+
+    public ObservedKafkaTemplate(
+            ProducerFactory<byte[], byte[]> producerFactory,
+            ObservationRegistry registry,
+            KafkaContextFactory contextFactory,
+            KafkaPublishConvention<KafkaRecordPublishContext> kafkaPublishConvention) {
+        super(producerFactory);
+        this.registry = registry;
+        this.contextFactory = contextFactory;
+        this.kafkaPublishConvention = kafkaPublishConvention;
+        this.setObservationEnabled(false);
+        this.setMicrometerEnabled(false);
+    }
+
+    @Override
+    public CompletableFuture<SendResult<byte[], byte[]>> send(ProducerRecord<byte[], byte[]> record) {
+        Assert.notNull(record, "'record' cannot be null");
+        return managedObserve(record);
+    }
+
+    @Override
+    public CompletableFuture<SendResult<byte[], byte[]>> send(String topic, byte[] data) {
+        return managedObserve(new ProducerRecord<>(topic, data));
+    }
+
+    @Override
+    public CompletableFuture<SendResult<byte[], byte[]>> send(String topic, byte[] key, byte[] data) {
+        return managedObserve(new ProducerRecord<>(topic, key, data));
+    }
+
+    @Override
+    public CompletableFuture<SendResult<byte[], byte[]>> send(String topic, Integer partition, byte[] key, byte[] data) {
+        return managedObserve(new ProducerRecord<>(topic, partition, key, data));
+    }
+
+    @Override
+    public CompletableFuture<SendResult<byte[], byte[]>> send(String topic, Integer partition, Long timestamp, byte[] key, byte[] data) {
+        return managedObserve(new ProducerRecord<>(topic, partition, timestamp, key, data));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public CompletableFuture<SendResult<byte[], byte[]>> send(Message<?> message) {
+        ProducerRecord<byte[], byte[]> producerRecord =
+                (ProducerRecord<byte[], byte[]>) getMessageConverter().fromMessage(message, getDefaultTopic());
+        if (!producerRecord.headers().iterator().hasNext()) { // possibly no Jackson
+            byte[] correlationId = message.getHeaders().get(KafkaHeaders.CORRELATION_ID, byte[].class);
+            if (correlationId != null) {
+                producerRecord.headers().add(KafkaHeaders.CORRELATION_ID, correlationId);
+            }
+        }
+        return managedObserve(producerRecord);
+    }
+
+    /**
+     * Управляет жизненным циклом Observation, координируя его с внутренним Callback-ом Kafka.
+     * whenComplete отрабатывает до вызова observation.stop() в Callback-е.
+     */
+    private CompletableFuture<SendResult<byte[], byte[]>> managedObserve(ProducerRecord<byte[], byte[]> record) {
+        KafkaRecordPublishContext context = contextFactory.createPublishContext(record);
+
+        Observation observation = Observation.createNotStarted(
+                null, kafkaPublishConvention,() -> context, registry);
+
+        observation.start();
+        try (Observation.Scope ignored = observation.openScope()) {
+            return super.doSend(record, observation)
+                    .whenComplete((result, throwable) -> {
+                        if (result != null && result.getRecordMetadata() != null) {
+                            var md = result.getRecordMetadata();
+                            context.setPartition(String.valueOf(md.partition()));
+                            context.setOffset(String.valueOf(md.offset()));
+                        }
+                    });
+        } catch (RuntimeException ex) {
+            if (context.getError() == null) {
+                observation.error(ex);
+                observation.stop();
+            }
+            throw ex;
+        }
+    }
+}

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/context/DetachedContext.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/context/DetachedContext.java
@@ -1,6 +1,7 @@
 package com.example.tasktracker.emailsender.o11y.observation.context;
 
 import io.micrometer.tracing.TraceContext;
+import org.springframework.lang.Nullable;
 
 /**
  * Указывает, что удаленный родитель (например, RECEIVE в Kafka) из заголовков может стать Link-ом,
@@ -8,7 +9,7 @@ import io.micrometer.tracing.TraceContext;
  */
 public interface DetachedContext {
 
-    TraceContext getRemoteParentLink();
+    @Nullable TraceContext getRemoteParentLink();
 
     void setRemoteParentLink(TraceContext context);
 }

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/context/KafkaContextFactory.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/context/KafkaContextFactory.java
@@ -1,0 +1,212 @@
+package com.example.tasktracker.emailsender.o11y.observation.context;
+
+
+import com.example.tasktracker.emailsender.config.AppProperties;
+import com.example.tasktracker.emailsender.messaging.util.KafkaHeaderReader;
+import com.example.tasktracker.emailsender.o11y.observation.context.kafka.*;
+import com.example.tasktracker.emailsender.o11y.observation.util.KafkaOtelPropagationUtils;
+import com.example.tasktracker.emailsender.o11y.observation.util.KafkaPropertiesResolver;
+import com.example.tasktracker.emailsender.pipeline.model.PipelineItem;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import static com.example.tasktracker.emailsender.api.messaging.MessagingHeaders.*;
+
+public class KafkaContextFactory {
+
+    private final KafkaPropertiesResolver resolver;
+    private final boolean doCaptureSizes;
+    private final TextMapPropagator propagator;
+
+    public KafkaContextFactory(KafkaPropertiesResolver resolver,
+                               AppProperties appProperties,
+                               TextMapPropagator propagator) {
+        this.resolver = resolver;
+        this.doCaptureSizes = appProperties.getObservability().isCaptureMessageSizes();
+        this.propagator = propagator;
+    }
+
+    public KafkaBatchReceiveContext createBatchReceiveContext(List<ConsumerRecord<byte[], byte[]>> records) {
+        return createBatchReceiveContext(records, KafkaBatchReceiveContext::new, null);
+    }
+
+    public <T extends KafkaBatchReceiveContext> T createBatchReceiveContext(List<ConsumerRecord<byte[], byte[]>> records,
+                                                                            Supplier<T> contextSupplier,
+                                                                            Consumer<T> dataEnhancer) {
+        T context = contextSupplier.get();
+
+        context.setCarrier(records);
+
+        String topic = records.stream().map(ConsumerRecord::topic).distinct().count() > 1 ?
+                KafkaBatchReceiveContext.MIXED_TOPIC_PLACEHOLDER :
+                records.getFirst().topic();
+
+        fillConnectionDetails(context, topic);
+
+        context.setBatchSize(records.size());
+
+        if (dataEnhancer != null)
+            dataEnhancer.accept(context);
+
+        return context;
+    }
+
+    public KafkaRecordReceiveContext createRecordReceiveContext(ConsumerRecord<byte[], byte[]> record) {
+        return createRecordReceiveContext(record, KafkaRecordReceiveContext::new, null);
+    }
+
+    public <T extends KafkaRecordReceiveContext> T createRecordReceiveContext(ConsumerRecord<byte[], byte[]> record,
+                                                                              Supplier<T> contextSupplier,
+                                                                              BiConsumer<T, ConsumerRecord<byte[], byte[]>> dataEnhancer) {
+        T context = contextSupplier.get();
+
+        context.setCarrier(record);
+
+        fillConnectionDetails(context, record.topic());
+
+        context.setMessageId(record.topic() + "-" + record.partition() + "@" + record.offset());
+        KafkaHeaderReader.readAsString(record, X_CORRELATION_ID).ifPresentOrElse(
+                context::setConversationId,
+                () -> context.setConversationId("unset"));
+        context.setPartition(String.valueOf(record.partition()));
+        context.setOffset(String.valueOf(record.offset()));
+
+        if (doCaptureSizes) {
+            context.setBodySize(calculateBodySize(record));
+            context.setEnvelopeSize(calculateEnvelopeSize(record));
+        }
+
+        setLinkToRemote(record.headers(), context);
+
+        if (dataEnhancer != null)
+            dataEnhancer.accept(context, record);
+
+        return context;
+    }
+
+
+    public KafkaRecordProcessContext createProcessContext(PipelineItem item) {
+        return createSingleProcessContext(item, KafkaRecordProcessContext::new, null);
+    }
+
+    public <T extends KafkaRecordProcessContext> T createSingleProcessContext(PipelineItem item,
+                                                                              Supplier<T> contextSupplier,
+                                                                              BiConsumer<T, PipelineItem> dataEnhancer) {
+        ConsumerRecord<byte[], byte[]> record = item.getOriginalRecord();
+
+        T context = contextSupplier.get();
+
+        fillConnectionDetails(context, record.topic());
+
+        context.setMessageId(item.getCoordinates());
+        context.setConversationId(item.getPayload().correlationId());
+        context.setPartition(String.valueOf(record.partition()));
+        context.setOffset(String.valueOf(record.offset()));
+
+        if (doCaptureSizes) {
+            context.setBodySize(calculateBodySize(record));
+            context.setEnvelopeSize(calculateEnvelopeSize(record));
+        }
+
+        setLinkToRemote(item.getOriginalRecord().headers(), context);
+
+        if (dataEnhancer != null)
+            dataEnhancer.accept(context, item);
+
+        return context;
+    }
+
+    public KafkaRecordPublishContext createRejectedContext(ProducerRecord<byte[], byte[]> record) {
+        return createPublishContext(record, KafkaRecordRejectContext::new, (ctx, rec) -> {
+            KafkaHeaderReader.readAsString(record, X_REJECT_REASON).ifPresent(ctx::setRejectReason);
+            KafkaHeaderReader.readAsString(record, X_REJECT_DESCRIPTION).ifPresent(ctx::setRejectDescription);
+
+        });
+    }
+
+    public KafkaRecordPublishContext createPublishContext(ProducerRecord<byte[], byte[]> record) {
+        Optional<String> rejectionHeader = KafkaHeaderReader.readAsString(record, X_REJECT_REASON);
+
+        return rejectionHeader.isPresent() ?
+                createRejectedContext(record) :
+                createPublishContext(record, KafkaRecordPublishContext::new, null);
+    }
+
+    public <T extends KafkaRecordPublishContext> T createPublishContext(ProducerRecord<byte[], byte[]> record,
+                                                                        Supplier<T> contextSupplier,
+                                                                        BiConsumer<T, ProducerRecord<byte[], byte[]>> dataEnhancer) {
+        T context = contextSupplier.get();
+
+        context.setCarrier(record);
+
+        context.setClientId(resolver.getClientId());
+        context.setServerAddress(resolver.getServerAddress());
+        context.setServerPort(resolver.getServerPort());
+
+        KafkaHeaderReader.readAsString(record, X_CORRELATION_ID).ifPresentOrElse(
+                context::setConversationId,
+                () -> context.setConversationId("unset"));
+
+        context.setTopic(record.topic());
+
+        if (doCaptureSizes) {
+            context.setBodySize(calculateBodySize(record));
+            context.setEnvelopeSize(calculateEnvelopeSize(record));
+        }
+
+        setLinkToRemote(record.headers(), context);
+
+        if (dataEnhancer != null)
+            dataEnhancer.accept(context, record);
+
+        return context;
+    }
+
+    private <T extends DetachedContext> void setLinkToRemote(Headers headers, T context) {
+        KafkaOtelPropagationUtils.addLinkFromHeaders(context, headers, propagator);
+    }
+
+    private void fillConnectionDetails(KafkaConnectionContext context, String topic) {
+        context.setClientId(resolver.getClientId());
+        context.setConsumerGroup(resolver.getConsumerGroup());
+        context.setServerAddress(resolver.getServerAddress());
+        context.setServerPort(resolver.getServerPort());
+        context.setTopic(topic);
+    }
+
+// --- Счётчики байтов ---
+
+    Long calculateBodySize(ConsumerRecord<byte[], byte[]> record) {
+        return record.value() != null ? (long) record.value().length : 0L;
+    }
+
+    Long calculateBodySize(ProducerRecord<byte[], byte[]> record) {
+        return record.value() != null ? (long) record.value().length : 0L;
+    }
+
+    Long calculateEnvelopeSize(ConsumerRecord<byte[], byte[]> record) {
+        long size = Math.max(0, record.serializedKeySize()) + Math.max(0, record.serializedValueSize());
+        for (Header header : record.headers()) {
+            size += header.key().length() + (header.value() != null ? header.value().length : 0) + 8; // approx varint overhead
+        }
+        return size + 12; // Magic overhead
+    }
+
+    Long calculateEnvelopeSize(ProducerRecord<byte[], byte[]> record) {
+        long size = calculateBodySize(record);
+        if (record.key() != null) size += record.key().length;
+        for (Header header : record.headers()) {
+            size += header.key().length() + (header.value() != null ? header.value().length : 0) + 8;
+        }
+        return size;
+    }
+}

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/context/kafka/KafkaBatchReceiveContext.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/context/kafka/KafkaBatchReceiveContext.java
@@ -1,0 +1,74 @@
+package com.example.tasktracker.emailsender.o11y.observation.context.kafka;
+
+import com.example.tasktracker.emailsender.o11y.observation.context.BatchContext;
+import com.example.tasktracker.emailsender.o11y.observation.context.DetachedContext;
+import com.example.tasktracker.emailsender.o11y.observation.convention.MessagingOperation;
+import io.micrometer.observation.transport.ReceiverContext;
+import io.micrometer.tracing.TraceContext;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Header;
+import org.springframework.lang.Nullable;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+/**
+ * Контекст для операций с батчами Kafka.
+ * <p>
+ * Контракт {@link ReceiverContext} требует наличия геттера для извлечения
+ * Trace-контекста. В данной реализации геттер формально указывает на первое
+ * сообщение в батче.
+ * <p>
+ * Однако, чтобы избежать ложной привязки всей операции вычитки к трейсу одного
+ * случайного сообщения, класс помечен интерфейсом {@link DetachedContext}, возвращающим null.
+ * Это обязует игнорировать trace parent и начинать новый трейс.
+ */
+@Getter
+@Setter
+public class KafkaBatchReceiveContext extends ReceiverContext<List<? extends ConsumerRecord<?, ?>>>
+        implements KafkaConnectionContext, BatchContext, DetachedContext {
+    public static final String MIXED_TOPIC_PLACEHOLDER = "_multiple_";
+
+    // Low Cardinality
+    private String clientId;
+    @Nullable
+    private String consumerGroup;
+    private String serverAddress;
+    private Integer serverPort;
+    private String topic;
+    // High Cardinality
+    private int batchSize;
+
+    public KafkaBatchReceiveContext() {
+        super((carrier, key) -> {
+            if (carrier.isEmpty())
+                return null;
+            Header header = carrier.getFirst().headers().lastHeader(key);
+            if (header == null || header.value() == null) {
+                return null;
+            }
+            return new String(header.value(), StandardCharsets.UTF_8);
+        });
+    }
+
+    @Override
+    public String getOperationType() {
+        return MessagingOperation.Type.RECEIVE;
+    }
+
+    @Override
+    public String getOperationName() {
+        return MessagingOperation.Name.POLL;
+    }
+
+    @Override
+    public TraceContext getRemoteParentLink() {
+        return null;
+    }
+
+    @Override
+    public void setRemoteParentLink(TraceContext context) {
+    }
+}

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/context/kafka/KafkaConnectionContext.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/context/kafka/KafkaConnectionContext.java
@@ -1,0 +1,23 @@
+package com.example.tasktracker.emailsender.o11y.observation.context.kafka;
+
+import org.springframework.lang.Nullable;
+
+public interface KafkaConnectionContext {
+    String getOperationType();
+    String getOperationName();
+
+    String getServerAddress();
+    void setServerAddress(String serverAddress);
+
+    Integer getServerPort();
+    void setServerPort(Integer serverPort);
+
+    String getClientId();
+    void setClientId(String clientId);
+
+    @Nullable String getConsumerGroup();
+    void setConsumerGroup(@Nullable String consumerGroup);
+
+    String getTopic();
+    void setTopic(String topic);
+}

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/context/kafka/KafkaMessageContext.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/context/kafka/KafkaMessageContext.java
@@ -1,0 +1,36 @@
+package com.example.tasktracker.emailsender.o11y.observation.context.kafka;
+
+import org.springframework.lang.Nullable;
+
+public interface KafkaMessageContext {
+    // High Cardinality
+
+    String getMessageId();
+
+    void setMessageId(String messageId);
+
+    String getConversationId();
+
+    void setConversationId(String conversationId);
+
+    @Nullable
+    String getPartition();
+
+    void setPartition(@Nullable String partition);
+
+    @Nullable String getOffset();
+
+    void setOffset(@Nullable String offset);
+
+    //Opt-in
+
+    @Nullable
+    Long getBodySize();
+
+    void setBodySize(@Nullable Long bodySize);
+
+    @Nullable
+    Long getEnvelopeSize();
+
+    void setEnvelopeSize(@Nullable Long envelopeSize);
+}

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/context/kafka/KafkaRecordProcessContext.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/context/kafka/KafkaRecordProcessContext.java
@@ -1,0 +1,47 @@
+package com.example.tasktracker.emailsender.o11y.observation.context.kafka;
+
+import com.example.tasktracker.emailsender.o11y.observation.context.DetachedContext;
+import com.example.tasktracker.emailsender.o11y.observation.convention.MessagingOperation;
+import io.micrometer.observation.Observation;
+import io.micrometer.tracing.TraceContext;
+import lombok.Getter;
+import lombok.Setter;
+import org.jetbrains.annotations.Nullable;
+
+@Getter
+@Setter
+public class KafkaRecordProcessContext extends Observation.Context
+        implements KafkaConnectionContext, KafkaMessageContext, DetachedContext {
+
+    private TraceContext remoteParentLink;
+    // Low Cardinality
+    private String clientId;
+    @Nullable
+    private String consumerGroup;
+    private String serverAddress;
+    private Integer serverPort;
+    private String topic;
+    // High Cardinality
+    private String messageId;
+    private String conversationId;
+    private String partition;
+    private String offset;
+    // Opt-in
+    @Nullable
+    private Long bodySize;
+    @Nullable
+    private Long envelopeSize;
+
+    public KafkaRecordProcessContext() {
+    }
+
+    @Override
+    public String getOperationType() {
+        return MessagingOperation.Type.PROCESS;
+    }
+
+    @Override
+    public String getOperationName() {
+        return MessagingOperation.Name.PROCESS;
+    }
+}

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/context/kafka/KafkaRecordPublishContext.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/context/kafka/KafkaRecordPublishContext.java
@@ -1,0 +1,58 @@
+package com.example.tasktracker.emailsender.o11y.observation.context.kafka;
+
+import com.example.tasktracker.emailsender.o11y.observation.context.DetachedContext;
+import com.example.tasktracker.emailsender.o11y.observation.convention.MessagingOperation;
+import io.micrometer.observation.transport.SenderContext;
+import io.micrometer.tracing.TraceContext;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.Headers;
+import org.springframework.lang.Nullable;
+
+import java.nio.charset.StandardCharsets;
+
+@Getter
+@Setter
+public class KafkaRecordPublishContext extends SenderContext<ProducerRecord<?, ?>>
+        implements KafkaConnectionContext, KafkaMessageContext, DetachedContext {
+
+    private TraceContext remoteParentLink;
+    // Low Cardinality
+    private String clientId;
+    @Nullable
+    private String consumerGroup;
+    private String serverAddress;
+    private Integer serverPort;
+    private String topic;
+    // High Cardinality
+    private String messageId;
+    private String conversationId;
+    private String partition;
+    private String offset;
+    // Opt-in
+    @Nullable
+    private Long bodySize;
+    @Nullable
+    private Long envelopeSize;
+
+    public KafkaRecordPublishContext() {
+        super((carrier, key, value) -> {
+            if (carrier == null)
+                return;
+            Headers headers = carrier.headers();
+            headers.remove(key);
+            headers.add(key, value.getBytes(StandardCharsets.UTF_8));
+        });
+    }
+
+    @Override
+    public String getOperationType() {
+        return MessagingOperation.Type.SEND;
+    }
+
+    @Override
+    public String getOperationName() {
+        return MessagingOperation.Name.PUBLISH;
+    }
+}

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/context/kafka/KafkaRecordReceiveContext.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/context/kafka/KafkaRecordReceiveContext.java
@@ -1,0 +1,51 @@
+package com.example.tasktracker.emailsender.o11y.observation.context.kafka;
+
+import com.example.tasktracker.emailsender.messaging.util.KafkaHeaderReader;
+import com.example.tasktracker.emailsender.o11y.observation.context.DetachedContext;
+import com.example.tasktracker.emailsender.o11y.observation.convention.MessagingOperation;
+import io.micrometer.observation.transport.ReceiverContext;
+import io.micrometer.tracing.TraceContext;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.jetbrains.annotations.Nullable;
+
+@Getter
+@Setter
+public class KafkaRecordReceiveContext extends ReceiverContext<ConsumerRecord<?, ?>>
+        implements KafkaConnectionContext, KafkaMessageContext, DetachedContext {
+
+    private TraceContext remoteParentLink;
+    // Low Cardinality
+    private String clientId;
+    @Nullable
+    private String consumerGroup;
+    private String serverAddress;
+    private Integer serverPort;
+    private String topic;
+    // High Cardinality
+    private String messageId;
+    private String conversationId;
+    private String partition;
+    private String offset;
+    // Opt-in
+    @Nullable
+    private Long bodySize;
+    @Nullable
+    private Long envelopeSize;
+
+    public KafkaRecordReceiveContext() {
+        super((carrier, key) ->
+                KafkaHeaderReader.readAsString(carrier, key).orElse(null));
+    }
+
+    @Override
+    public String getOperationType() {
+        return MessagingOperation.Type.RECEIVE;
+    }
+
+    @Override
+    public String getOperationName() {
+        return MessagingOperation.Name.POLL;
+    }
+}

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/context/kafka/KafkaRecordRejectContext.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/context/kafka/KafkaRecordRejectContext.java
@@ -1,0 +1,17 @@
+package com.example.tasktracker.emailsender.o11y.observation.context.kafka;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.lang.Nullable;
+
+@Getter
+@Setter
+public class KafkaRecordRejectContext extends KafkaRecordPublishContext {
+    // Low Cardinality
+    @Nullable
+    private String rejectReason;
+    // High Cardinality
+    @Nullable
+    private String rejectDescription;
+
+}

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/convention/BaseKafkaMessagingConvention.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/convention/BaseKafkaMessagingConvention.java
@@ -1,0 +1,72 @@
+package com.example.tasktracker.emailsender.o11y.observation.convention;
+
+import com.example.tasktracker.emailsender.o11y.observation.context.BatchContext;
+import com.example.tasktracker.emailsender.o11y.observation.context.kafka.KafkaConnectionContext;
+import com.example.tasktracker.emailsender.o11y.observation.context.kafka.KafkaMessageContext;
+import io.micrometer.common.KeyValues;
+import io.micrometer.observation.Observation;
+
+import static com.example.tasktracker.emailsender.o11y.observation.convention.KafkaObservationTags.HighCardinality.*;
+import static com.example.tasktracker.emailsender.o11y.observation.convention.KafkaObservationTags.LowCardinality.*;
+
+public abstract class BaseKafkaMessagingConvention<T extends Observation.Context & KafkaConnectionContext> extends BaseO11yConvention<T> {
+    /**
+     * Формирует имя спана согласно OTel Spec для Messaging: {@code {messaging.operation.name} {destination}}.
+     * Пример: {@code user_welcome publish}
+     */
+    @Override
+    public String getContextualName(T context) {
+        return context.getOperationName() + " " + context.getTopic();
+    }
+
+    @Override
+    public KeyValues getLowCardinalityKeyValues(T context) {
+        KeyValues kvs = super.getLowCardinalityKeyValues(context).and(
+                SYSTEM.asString(), "kafka",
+                OP_NAME.asString(), context.getOperationName(),
+                OP_TYPE.asString(), context.getOperationType(),
+                DESTINATION.asString(), context.getTopic(),
+                CLIENT_ID.asString(), context.getClientId(),
+                SERVER_ADDRESS.asString(), context.getServerAddress(),
+                SERVER_PORT.asString(), String.valueOf(context.getServerPort())
+        );
+
+        if (context.getConsumerGroup() != null) {
+            kvs = kvs.and(CONSUMER_GROUP.asString(), context.getConsumerGroup());
+        }
+
+        return kvs;
+    }
+
+    @Override
+    public KeyValues getHighCardinalityKeyValues(T context) {
+        KeyValues kvs = super.getHighCardinalityKeyValues(context);
+
+        if (context instanceof KafkaMessageContext messageContext) {
+            if (messageContext.getMessageId() != null) {
+                kvs = kvs.and(MESSAGE_ID.asString(), messageContext.getMessageId());
+            }
+            if (messageContext.getConversationId() != null) {
+                kvs = kvs.and(CONVERSATION_ID.asString(), messageContext.getConversationId());
+            }
+            if (messageContext.getOffset() != null) {
+                kvs = kvs.and(OFFSET.asString(), messageContext.getOffset());
+            }
+            if (messageContext.getPartition() != null) {
+                kvs = kvs.and(PARTITION.asString(), messageContext.getPartition());
+            }
+            if (messageContext.getBodySize() != null) {
+                kvs = kvs.and(BODY_SIZE.asString(), String.valueOf(messageContext.getBodySize()));
+            }
+            if (messageContext.getEnvelopeSize() != null) {
+                kvs = kvs.and(ENVELOPE_SIZE.asString(), String.valueOf(messageContext.getEnvelopeSize()));
+            }
+        }
+
+        if (context instanceof BatchContext batchContext) {
+            kvs = kvs.and(BATCH_SIZE.asString(), String.valueOf(batchContext.getBatchSize()));
+        }
+
+        return kvs;
+    }
+}

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/convention/BaseO11yConvention.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/convention/BaseO11yConvention.java
@@ -1,11 +1,16 @@
 package com.example.tasktracker.emailsender.o11y.observation.convention;
 
 import io.micrometer.common.KeyValues;
+import io.micrometer.observation.GlobalObservationConvention;
 import io.micrometer.observation.Observation;
-import io.micrometer.observation.ObservationConvention;
 import io.opentelemetry.semconv.ErrorAttributes;
 
-public abstract class BaseO11yConvention<T extends Observation.Context> implements ObservationConvention<T> {
+public abstract class BaseO11yConvention<T extends Observation.Context> implements GlobalObservationConvention<T> {
+    @Override
+    public boolean supportsContext(Observation.Context context) {
+        return false;
+    }
+
     @Override
     public KeyValues getLowCardinalityKeyValues(T context) {
         if (context.getError() != null) {

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/convention/KafkaObservationTags.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/convention/KafkaObservationTags.java
@@ -1,0 +1,104 @@
+package com.example.tasktracker.emailsender.o11y.observation.convention;
+
+import io.micrometer.common.docs.KeyName;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class KafkaObservationTags {
+    public enum LowCardinality implements KeyName {
+
+        SYSTEM {
+            @Override
+            public String asString() {
+                return "messaging.system";
+            }
+        },
+        OP_TYPE {
+            @Override
+            public String asString() {
+                return "messaging.operation.type";
+            }
+        },
+        OP_NAME {
+            @Override
+            public String asString() {
+                return "messaging.operation.name";
+            }
+        },
+        DESTINATION {
+            @Override
+            public String asString() {
+                return "messaging.destination.name";
+            }
+        },
+        CONSUMER_GROUP {
+            @Override
+            public String asString() {
+                return "messaging.consumer.group.name";
+            }
+        },
+        CLIENT_ID {
+            @Override
+            public String asString() {
+                return "messaging.client.id";
+            }
+        },
+        SERVER_ADDRESS {
+            @Override
+            public String asString() {
+                return "server.address";
+            }
+        },
+        SERVER_PORT {
+            @Override
+            public String asString() {
+                return "server.port";
+            }
+        },
+        BATCH_SIZE {
+            @Override
+            public String asString() {
+                return "messaging.batch.message_count";
+            }
+        }
+    }
+
+    public enum HighCardinality implements KeyName {
+        MESSAGE_ID {
+            @Override
+            public String asString() {
+                return "messaging.message.id";
+            }
+        },
+        CONVERSATION_ID {
+            @Override
+            public String asString() {
+                return "messaging.message.conversation_id";
+            }
+        },
+        OFFSET {
+            @Override
+            public String asString() {
+                return "messaging.kafka.offset";
+            }
+        },
+        PARTITION {
+            @Override
+            public String asString() {
+                return "messaging.destination.partition.id";
+            }
+        },
+        BODY_SIZE {
+            @Override
+            public String asString() {
+                return "messaging.message.body.size";
+            }
+        },
+        ENVELOPE_SIZE {
+            @Override
+            public String asString() {
+                return "messaging.message.envelope.size";
+            }
+        }
+    }
+}

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/convention/KafkaProcessConvention.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/convention/KafkaProcessConvention.java
@@ -1,0 +1,16 @@
+ package com.example.tasktracker.emailsender.o11y.observation.convention;
+
+import com.example.tasktracker.emailsender.o11y.observation.context.kafka.KafkaRecordProcessContext;
+import io.micrometer.observation.Observation;
+
+public class KafkaProcessConvention extends BaseKafkaMessagingConvention<KafkaRecordProcessContext> {
+    @Override
+    public String getName() {
+        return "messaging.process.duration";
+    }
+
+    @Override
+    public boolean supportsContext(Observation.Context context) {
+        return context.getClass() == KafkaRecordProcessContext.class;
+    }
+}

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/convention/KafkaPublishConvention.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/convention/KafkaPublishConvention.java
@@ -1,0 +1,16 @@
+package com.example.tasktracker.emailsender.o11y.observation.convention;
+
+import com.example.tasktracker.emailsender.o11y.observation.context.kafka.KafkaRecordPublishContext;
+import io.micrometer.observation.Observation;
+
+public class KafkaPublishConvention<T extends KafkaRecordPublishContext> extends BaseKafkaMessagingConvention<T> {
+    @Override
+    public String getName() {
+        return "messaging.client.operation.duration";
+    }
+
+    @Override
+    public boolean supportsContext(Observation.Context context) {
+        return context.getClass() == KafkaRecordPublishContext.class;
+    }
+}

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/convention/KafkaReceiveConvention.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/convention/KafkaReceiveConvention.java
@@ -1,0 +1,20 @@
+package com.example.tasktracker.emailsender.o11y.observation.convention;
+
+import com.example.tasktracker.emailsender.o11y.observation.context.kafka.KafkaBatchReceiveContext;
+import com.example.tasktracker.emailsender.o11y.observation.context.kafka.KafkaConnectionContext;
+import com.example.tasktracker.emailsender.o11y.observation.context.kafka.KafkaRecordReceiveContext;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.transport.ReceiverContext;
+
+public class KafkaReceiveConvention<T extends ReceiverContext<?> & KafkaConnectionContext>
+        extends BaseKafkaMessagingConvention<T> {
+    @Override
+    public String getName() {
+        return "messaging.client.operation.duration";
+    }
+
+    @Override
+    public boolean supportsContext(Observation.Context context) {
+        return context.getClass() == KafkaRecordReceiveContext.class || context.getClass() == KafkaBatchReceiveContext.class;
+    }
+}

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/convention/KafkaRejectPublishConvention.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/convention/KafkaRejectPublishConvention.java
@@ -1,0 +1,53 @@
+package com.example.tasktracker.emailsender.o11y.observation.convention;
+
+import com.example.tasktracker.emailsender.o11y.observation.context.kafka.KafkaRecordRejectContext;
+import io.micrometer.common.KeyValues;
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.observation.Observation;
+
+public class KafkaRejectPublishConvention extends KafkaPublishConvention<KafkaRecordRejectContext> {
+    public enum LowCardinalityTags implements KeyName {
+        REJECT_REASON {
+            @Override
+            public String asString() {
+                return "email_sender.rejection.reason";
+            }
+        }
+    }
+
+    public enum HighCardinalityTags implements KeyName {
+        REJECT_DESCRIPTION {
+            @Override
+            public String asString() {
+                return "email_sender.rejection.description";
+            }
+        }
+    }
+
+    @Override
+    public boolean supportsContext(Observation.Context context) {
+        return context.getClass() == KafkaRecordRejectContext.class;
+    }
+
+    @Override
+    public KeyValues getLowCardinalityKeyValues(KafkaRecordRejectContext context) {
+        KeyValues kvs = super.getLowCardinalityKeyValues(context);
+
+        if (context.getRejectReason() != null) {
+            kvs = kvs.and(LowCardinalityTags.REJECT_REASON.asString(), context.getRejectReason().toLowerCase());
+        }
+
+        return kvs;
+    }
+
+    @Override
+    public KeyValues getHighCardinalityKeyValues(KafkaRecordRejectContext context) {
+        KeyValues kvs = super.getHighCardinalityKeyValues(context);
+
+        if (context.getRejectDescription() != null) {
+            kvs = kvs.and(HighCardinalityTags.REJECT_DESCRIPTION.asString(), context.getRejectDescription().toLowerCase());
+        }
+
+        return kvs;
+    }
+}

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/convention/MessagingOperation.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/convention/MessagingOperation.java
@@ -1,0 +1,20 @@
+package com.example.tasktracker.emailsender.o11y.observation.convention;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public final class MessagingOperation {
+    public static final class Type {
+        public static final String CREATE = "create";
+        public static final String PROCESS = "process";
+        public static final String RECEIVE = "receive";
+        public static final String SEND = "send";
+        public static final String SETTLE = "settle";
+    }
+
+    public static final class Name {
+        public static final String PUBLISH = "publish";
+        public static final String POLL = "pool";
+        public static final String PROCESS = "process";
+    }
+}

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/handler/KafkaMessagingMetricsHandler.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/handler/KafkaMessagingMetricsHandler.java
@@ -1,0 +1,80 @@
+package com.example.tasktracker.emailsender.o11y.observation.handler;
+
+import com.example.tasktracker.emailsender.o11y.observation.context.BatchContext;
+import com.example.tasktracker.emailsender.o11y.observation.context.kafka.KafkaConnectionContext;
+import com.example.tasktracker.emailsender.o11y.observation.convention.MessagingOperation;
+import io.micrometer.common.KeyValue;
+import io.micrometer.common.KeyValues;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationHandler;
+import io.micrometer.observation.transport.ReceiverContext;
+import io.micrometer.observation.transport.SenderContext;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Iterator;
+
+@RequiredArgsConstructor
+public class KafkaMessagingMetricsHandler<T extends Observation.Context & KafkaConnectionContext> implements ObservationHandler<T> {
+
+    private final MeterRegistry meterRegistry;
+
+    @Override
+    public boolean supportsContext(Observation.Context context) {
+        return context instanceof KafkaConnectionContext &&
+                (context instanceof SenderContext || context instanceof ReceiverContext);
+    }
+
+    @Override
+    public void onStop(T context) {
+        String op = context.getOperationType();
+
+        int count = 1;
+        if (context instanceof BatchContext batchContext)
+            count = batchContext.getBatchSize();
+
+        String metricName = resolveMessagingCounterName(op);
+
+        if (metricName != null)
+            incrementCounter(metricName, context, count);
+
+    }
+
+    private @Nullable String resolveMessagingCounterName(String op) {
+        return switch (op) {
+            case MessagingOperation.Type.RECEIVE -> "messaging.client.consumed.messages";
+            case MessagingOperation.Type.SEND -> "messaging.client.sent.messages";
+            default -> null;
+        };
+    }
+
+    private void incrementCounter(String metricName, T context, int amount) {
+        meterRegistry.counter(
+                        metricName,
+                        new KeyValuesTagsAdapter(context.getLowCardinalityKeyValues()))
+                .increment(amount);
+    }
+
+    private record KeyValuesTagsAdapter(KeyValues keyValues) implements Iterable<Tag> {
+        @Override
+        public @NotNull Iterator<Tag> iterator() {
+            return new Iterator<>() {
+                private final Iterator<KeyValue> it = keyValues.iterator();
+
+                @Override
+                public boolean hasNext() {
+                    return it.hasNext();
+                }
+
+                @Override
+                public Tag next() {
+                    KeyValue kv = it.next();
+                    return Tag.of(kv.getKey(), kv.getValue());
+                }
+            };
+        }
+    }
+}

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/handler/LinkingPropagatingTracingObservationHandler.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/handler/LinkingPropagatingTracingObservationHandler.java
@@ -1,6 +1,7 @@
 package com.example.tasktracker.emailsender.o11y.observation.handler;
 
 import com.example.tasktracker.emailsender.o11y.observation.context.DetachedContext;
+import com.example.tasktracker.emailsender.o11y.observation.context.kafka.KafkaConnectionContext;
 import io.micrometer.common.util.StringUtils;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.transport.ReceiverContext;
@@ -57,6 +58,10 @@ public class LinkingPropagatingTracingObservationHandler extends DefaultTracingO
             builder.kind(Span.Kind.valueOf(sc.getKind().name()));
             builder.remoteServiceName(sc.getRemoteServiceName());
             setRemoteCoords(sc.getRemoteServiceAddress(), builder);
+        }
+
+        if (context instanceof KafkaConnectionContext kcc && kcc.getServerAddress() != null) {
+            builder.remoteIpAndPort(kcc.getServerAddress(), kcc.getServerPort());
         }
 
         Span span = builder.start();

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/util/KafkaOtelPropagationUtils.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/util/KafkaOtelPropagationUtils.java
@@ -1,0 +1,64 @@
+package com.example.tasktracker.emailsender.o11y.observation.util;
+
+import com.example.tasktracker.emailsender.o11y.observation.context.DetachedContext;
+import io.micrometer.tracing.TraceContext;
+import io.micrometer.tracing.otel.bridge.OtelTraceContext;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import lombok.experimental.UtilityClass;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+
+import java.nio.charset.StandardCharsets;
+import java.util.stream.StreamSupport;
+
+/**
+ * Утилита для ручного управления context propagation в Kafka с использованием моста OpenTelemetry.
+ */
+@UtilityClass
+public class KafkaOtelPropagationUtils {
+
+    private static final TextMapGetter<Headers> KAFKA_HEADER_GETTER = new TextMapGetter<>() {
+        @Override
+        public Iterable<String> keys(Headers carrier) {
+            return StreamSupport.stream(carrier.spliterator(), false)
+                    .map(Header::key)
+                    .toList();
+        }
+
+        @Override
+        public String get(Headers carrier, String key) {
+            if (carrier == null)
+                return null;
+
+            Header header = carrier.lastHeader(key);
+            if (header == null || header.value() == null) {
+                return null;
+            }
+
+            return new String(header.value(), StandardCharsets.UTF_8);
+        }
+    };
+
+    /**
+     * Извлекает контекст продюсера из заголовков Kafka.
+     */
+    public static TraceContext extract(Headers headers, TextMapPropagator propagator) {
+        Context producerOtelContext = propagator.extract(Context.root(), headers, KAFKA_HEADER_GETTER);
+
+        SpanContext producerOtelSpanContext = Span.fromContext(producerOtelContext).getSpanContext();
+
+        if (!producerOtelSpanContext.isValid()) {
+            return null;
+        }
+        return OtelTraceContext.fromOtel(producerOtelSpanContext);
+    }
+
+    public static void addLinkFromHeaders(DetachedContext context, Headers headers, TextMapPropagator propagator) {
+        TraceContext producerContext = extract(headers, propagator);
+        context.setRemoteParentLink(producerContext);
+    }
+}

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/util/KafkaPropertiesResolver.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/util/KafkaPropertiesResolver.java
@@ -1,0 +1,122 @@
+package com.example.tasktracker.emailsender.o11y.observation.util;
+
+import com.example.tasktracker.emailsender.infra.RuntimeInstanceIdProvider;
+import lombok.Getter;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.kafka.KafkaConnectionDetails;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+/**
+ * мусорный класс-костыль.
+ */
+@Component
+public class KafkaPropertiesResolver {
+
+    @Getter
+    private final String clientId;
+
+    @Getter
+    private final String consumerGroup;
+
+    @Getter
+    private final String serverAddress;
+
+    @Getter
+    private final int serverPort;
+
+    public KafkaPropertiesResolver(
+            KafkaProperties kafkaProperties,
+            ObjectProvider<KafkaConnectionDetails> connectionDetailsProvider,
+            RuntimeInstanceIdProvider instanceIdProvider,
+            @Value("${spring.application.name}") String appName) {
+
+        this.clientId = determineClientId(kafkaProperties, appName, instanceIdProvider.getInstanceId());
+        this.consumerGroup = determineConsumerGroup(kafkaProperties);
+
+        KafkaConnectionDetails details = connectionDetailsProvider.getIfAvailable();
+        List<String> bootstrapServers = (details != null)
+                ? details.getBootstrapServers()
+                : kafkaProperties.getBootstrapServers();
+
+        ServerEndpoint endpoint = determineServerEndpoint(bootstrapServers);
+        this.serverAddress = endpoint.host();
+        this.serverPort = endpoint.port();
+    }
+
+    private String determineClientId(KafkaProperties props, String appName, String instanceId) {
+        if (StringUtils.hasText(props.getConsumer().getClientId())) {
+            return props.getConsumer().getClientId();
+        }
+        if (StringUtils.hasText(props.getClientId())) {
+            return props.getClientId();
+        }
+        return appName + "@" + instanceId;
+    }
+
+    private String determineConsumerGroup(KafkaProperties props) {
+        if (StringUtils.hasText(props.getConsumer().getGroupId())) {
+            return props.getConsumer().getGroupId();
+        }
+        return "default-consumer-group";
+    }
+
+    /**
+     * Парсит список bootstrap серверов.
+     * Если их несколько, объединяет хосты через запятую для OTel SemConv.
+     */
+    private ServerEndpoint determineServerEndpoint(@NonNull List<String> bootstrapServers) {
+        List<String> servers = bootstrapServers.stream().sorted().toList();
+
+        if (servers.size() == 1) {
+            return parseEndpoint(servers.getFirst());
+        }
+
+        // OTel SemConv: server.address = "kafka1,kafka2,kafka3", server.port = 9092 (если порты одинаковые)
+        StringBuilder hostBuilder = new StringBuilder();
+        int commonPort = -1;
+        boolean multiPort = false;
+
+        for (int i = 0; i < servers.size(); i++) {
+            ServerEndpoint ep = parseEndpoint(servers.get(i));
+            hostBuilder.append(ep.host());
+            if (i < servers.size() - 1) {
+                hostBuilder.append(",");
+            }
+
+            if (commonPort == -1) {
+                commonPort = ep.port();
+            } else if (commonPort != ep.port()) {
+                multiPort = true;
+            }
+        }
+
+        // Если в кластере брокеры висят на разных портах, порт не указываем
+        return new ServerEndpoint(hostBuilder.toString(), multiPort ? -1 : commonPort);
+    }
+
+    private ServerEndpoint parseEndpoint(String server) {
+        if (!server.contains(":")) {
+            return new ServerEndpoint(server, 9092);
+        }
+
+        // IPv6: [2001:db8::1]:9092
+        int lastColon = server.lastIndexOf(':');
+        String host = server.substring(0, lastColon).replace("[", "").replace("]", "");
+        int port;
+        try {
+            port = Integer.parseInt(server.substring(lastColon + 1));
+        } catch (NumberFormatException e) {
+            port = 9092;
+        }
+
+        return new ServerEndpoint(host, port);
+    }
+
+    private record ServerEndpoint(String host, int port) {}
+}

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/pipeline/assembler/processor/MetadataResolver.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/pipeline/assembler/processor/MetadataResolver.java
@@ -14,8 +14,8 @@ public class MetadataResolver implements ItemProcessor {
     @Override
     public void process(PipelineItem item) {
         ConsumerRecord<byte[], byte[]> record = item.getOriginalRecord();
-        item.setTemplateIdHeader(KafkaHeaderReader.readString(record, X_TEMPLATE_ID).orElse(null));
-        item.setValidUntilHeader(KafkaHeaderReader.readString(record, X_VALID_UNTIL).orElse(null));
-        item.setCorrelationIdHeader(KafkaHeaderReader.readString(record, X_CORRELATION_ID).orElse(null));
+        item.setTemplateIdHeader(KafkaHeaderReader.readAsString(record, X_TEMPLATE_ID).orElse(null));
+        item.setValidUntilHeader(KafkaHeaderReader.readAsString(record, X_VALID_UNTIL).orElse(null));
+        item.setCorrelationIdHeader(KafkaHeaderReader.readAsString(record, X_CORRELATION_ID).orElse(null));
     }
 }


### PR DESCRIPTION
Этот PR внедряет продвинутый слой обсервабилити для Kafka, который заменяет стандартную инструментацию Spring. Мы реализовали модель, полностью соответствующую спецификации **OpenTelemetry Messaging Semantic Conventions**, с особым упором на предотвращение раздувания трейсов и корректную типизацию метрик:

1.  **Борьба с Trace Explosion**: 
    Стандартное поведение Micrometer/Spring Kafka создает жесткую иерархию Parent-Child между всеми участниками обмена сообщениями. В нагруженных системах это приводит к «бесконечным» трейсам. Мы внедрили маркер **`DetachedContext`**, который разрывает ошибочное дефолтное поведение и заменяет его на **Span Links** согласно спецификации OTel. Это позволяет отслеживать путь сообщения, сохраняя трейсы короткими и изолированными.

2.  **Compliance с OpenTelemetry semconv**: 
    Мы исправили критическое несоответствие имен и атрибутов стандартам. 
    *   Имена спанов теперь строго соответствуют формату `{messaging.operation.name} {destination}`. 
    *   Наборы аттрибутов спанов/метрик соответствуют semconv.

3.  **Прозрачная подмена инфраструктуры (ObservedKafkaTemplate)**: 
    Разработана кастомная версия `ObservedKafkaTemplate`, поддерживающая нашу модель конвенций. Она интегрирована в стандартный флоу Spring Kafka через **`KafkaObservabilityEnhancer`** (BeanPostProcessor). Подмена происходит только для байтовых шаблонов и сохраняет состояние оригинала.

4.  **Наблюдаемость DLT и Ретраев**: 
    Введен специализированный **`KafkaRecordRejectContext`** и два кастомных атрибута для детального мониторинга отказов. Теперь причины попадания в DLT (Rejection Reason/Description) доступны прямо в трейсах и метриках, что позволяет строить аналитику по качеству входящего трафика.