### PR TITLE
feat(email-sender): implement idempotency layer observability

### DIFF
--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/context/RedisContextFactory.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/context/RedisContextFactory.java
@@ -1,0 +1,39 @@
+package com.example.tasktracker.emailsender.o11y.observation.context;
+
+import com.example.tasktracker.emailsender.o11y.observation.util.RedisPropertiesResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisContextFactory {
+
+    private final RedisPropertiesResolver redisPropertiesResolver;
+
+    /**
+     * Создает контекст для Redis операции.
+     *
+     * @param operationName Имя команды (EVAL, SET, etc)
+     * @param scriptSha1    sha1 скрипта (для db.stored_procedure.name)
+     * @param batchSize     Размер батча (для db.operation.batch.size)
+     */
+    public RedisObservationContext createContext(String operationName,
+                                                 String logicalOperationName,
+                                                 Integer batchSize,
+                                                 String scriptSha1) {
+        RedisObservationContext context = new RedisObservationContext(
+                operationName,
+                logicalOperationName,
+                redisPropertiesResolver.getAddress(),
+                redisPropertiesResolver.getPort(),
+                redisPropertiesResolver.getDatabaseIndex()
+        );
+
+        context.setRemoteServiceName("redis");
+
+        if (batchSize != null) context.setBatchSize(batchSize);
+        if (scriptSha1 != null) context.setScriptSha1(scriptSha1);
+
+        return context;
+    }
+}

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/context/RedisObservationContext.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/context/RedisObservationContext.java
@@ -1,0 +1,28 @@
+package com.example.tasktracker.emailsender.o11y.observation.context;
+
+import io.micrometer.observation.transport.Kind;
+import io.micrometer.observation.transport.SenderContext;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Objects;
+
+@Getter
+public class RedisObservationContext extends SenderContext<Object> {
+    private final String operationName;
+    private final String logicalOperationName;
+    private final String databaseIndex;
+    private final String serverAddress;
+    private final int port;
+    @Setter private Integer batchSize;
+    @Setter private String scriptSha1;
+
+    public RedisObservationContext(String operationName, String logicalOperationName, String address, int port, String dbIndex) {
+        super((carrier, key, value) -> {}, Kind.CLIENT);
+        this.operationName = Objects.requireNonNull(operationName);
+        this.logicalOperationName = Objects.requireNonNull(logicalOperationName);
+        this.databaseIndex = Objects.requireNonNull(dbIndex);
+        this.serverAddress = Objects.requireNonNull(address);
+        this.port = port;
+    }
+}

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/convention/MessagingOperation.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/convention/MessagingOperation.java
@@ -14,7 +14,7 @@ public final class MessagingOperation {
 
     public static final class Name {
         public static final String PUBLISH = "publish";
-        public static final String POLL = "pool";
+        public static final String POLL = "poll";
         public static final String PROCESS = "process";
     }
 }

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/convention/RedisConvention.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/convention/RedisConvention.java
@@ -1,0 +1,56 @@
+package com.example.tasktracker.emailsender.o11y.observation.convention;
+
+import com.example.tasktracker.emailsender.o11y.observation.context.RedisObservationContext;
+import io.micrometer.common.KeyValues;
+import io.micrometer.observation.Observation;
+import jakarta.validation.constraints.NotNull;
+
+import static com.example.tasktracker.emailsender.o11y.observation.convention.RedisObservationTags.HighCardinality.*;
+import static com.example.tasktracker.emailsender.o11y.observation.convention.RedisObservationTags.LowCardinality.*;
+
+
+public class RedisConvention extends BaseO11yConvention<RedisObservationContext> {
+
+    @Override
+    public @NotNull KeyValues getLowCardinalityKeyValues(RedisObservationContext context) {
+        String procedureName = context.getScriptSha1() == null ? context.getLogicalOperationName() : context.getScriptSha1();
+
+        return super.getLowCardinalityKeyValues(context).and(
+                SYSTEM.asString(), "redis",
+                OPERATION.asString(), context.getOperationName(),
+                LOGICAL_OPERATION.asString(), context.getLogicalOperationName(),
+                NAMESPACE.asString(), context.getDatabaseIndex(),
+                SERVER_ADDRESS.asString(), context.getServerAddress(),
+                SERVER_PORT.asString(), String.valueOf(context.getPort()),
+                PROCEDURE_NAME.asString(), procedureName
+        );
+    }
+
+    @Override
+    public @NotNull KeyValues getHighCardinalityKeyValues(@NotNull RedisObservationContext context) {
+        KeyValues kvs = super.getHighCardinalityKeyValues(context);
+
+        if (context.getBatchSize() != null && context.getBatchSize() > 1) {
+            kvs = kvs.and(BATCH_SIZE.asString(), String.valueOf(context.getBatchSize()));
+        }
+
+        return kvs;
+    }
+
+    @Override
+    public String getName() {
+        return "db.client.operation.duration";
+    }
+
+    @Override
+    public String getContextualName(RedisObservationContext context) {
+        // [SemConv] Span name SHOULD be {db.operation.name} {db.stored_procedure.name}
+        String spanName = context.getScriptSha1() == null ? context.getLogicalOperationName() : context.getScriptSha1();
+        return context.getOperationName() + " " + spanName;
+    }
+
+    @Override
+    public boolean supportsContext(Observation.Context context) {
+        return context.getClass() == RedisObservationContext.class;
+    }
+}

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/convention/RedisObservationTags.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/convention/RedisObservationTags.java
@@ -1,0 +1,61 @@
+package com.example.tasktracker.emailsender.o11y.observation.convention;
+
+import io.micrometer.common.docs.KeyName;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class RedisObservationTags {
+    public enum LowCardinality implements KeyName {
+        SYSTEM {
+            @Override
+            public String asString() {
+                return "db.system.name";
+            }
+        },
+        OPERATION {
+            @Override
+            public String asString() {
+                return "db.operation.name";
+            }
+        },
+        LOGICAL_OPERATION {
+            @Override
+            public String asString() {
+                return "logical.operation.name";
+            }
+        },
+        NAMESPACE {
+            @Override
+            public String asString() {
+                return "db.namespace";
+            }
+        },
+        PROCEDURE_NAME {
+            @Override
+            public String asString() {
+                return "db.stored_procedure.name";
+            }
+        },
+        SERVER_ADDRESS {
+            @Override
+            public String asString() {
+                return "server.address";
+            }
+        },
+        SERVER_PORT {
+            @Override
+            public String asString() {
+                return "server.port";
+            }
+        }
+    }
+
+    public enum HighCardinality implements KeyName {
+        BATCH_SIZE {
+            @Override
+            public String asString() {
+                return "db.operation.batch.size";
+            }
+        }
+    }
+}

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/util/RedisPropertiesResolver.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/util/RedisPropertiesResolver.java
@@ -1,0 +1,33 @@
+package com.example.tasktracker.emailsender.o11y.observation.util;
+
+import lombok.Getter;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.data.redis.RedisConnectionDetails;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@Getter
+public class RedisPropertiesResolver {
+    private final String address;
+    private final int port;
+    private final String databaseIndex;
+
+    public RedisPropertiesResolver(
+            RedisProperties properties,
+            ObjectProvider<RedisConnectionDetails> connectionDetailsProvider) {
+
+        RedisConnectionDetails details = connectionDetailsProvider.getIfAvailable();
+
+        if (details != null && details.getStandalone() != null) {
+            var standalone = details.getStandalone();
+            this.address = standalone.getHost();
+            this.port = standalone.getPort();
+            this.databaseIndex = String.valueOf(standalone.getDatabase());
+        } else {
+            this.address = properties.getHost() != null ? properties.getHost() : "localhost";
+            this.port = properties.getPort() != 0 ? properties.getPort() : 6379;
+            this.databaseIndex = String.valueOf(properties.getDatabase());
+        }
+    }
+}

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/pipeline/ObservedIdempotencyCommitter.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/pipeline/ObservedIdempotencyCommitter.java
@@ -1,0 +1,52 @@
+package com.example.tasktracker.emailsender.o11y.pipeline;
+
+import com.example.tasktracker.emailsender.o11y.observation.context.RedisContextFactory;
+import com.example.tasktracker.emailsender.o11y.observation.context.RedisObservationContext;
+import com.example.tasktracker.emailsender.o11y.observation.convention.RedisConvention;
+import com.example.tasktracker.emailsender.pipeline.idempotency.IdempotencyCommitter;
+import com.example.tasktracker.emailsender.pipeline.model.PipelineBatch;
+import com.example.tasktracker.emailsender.pipeline.model.PipelineItem;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class ObservedIdempotencyCommitter implements IdempotencyCommitter {
+    private static final String CONV_OPERATION_NAME = "PIPELINE";
+    private static final String DISCRETE_CONV_OPERATION_NAME = "SET";
+
+    private static final String LOGICAL_OPERATION_NAME = "idempotency.commit";
+
+    private final IdempotencyCommitter delegate;
+    private final RedisContextFactory contextFactory;
+    private final ObservationRegistry registry;
+    private final RedisConvention redisConvention;
+
+    @Override
+    public void commitSuccess(PipelineBatch batch) {
+        var sentItems = batch.getSentItems();
+        if (sentItems.isEmpty()) return;
+
+        RedisObservationContext context = contextFactory.createContext(
+                CONV_OPERATION_NAME,
+                LOGICAL_OPERATION_NAME,
+                sentItems.size(),
+                null
+        );
+
+        Observation.createNotStarted(redisConvention, () -> context, registry)
+                .observe(() -> delegate.commitSuccess(batch));
+    }
+
+    @Override
+    public void commitSuccess(PipelineItem item) {
+        RedisObservationContext context = contextFactory.createContext(
+                DISCRETE_CONV_OPERATION_NAME,
+                LOGICAL_OPERATION_NAME,
+                null,
+                null);
+
+        Observation.createNotStarted(redisConvention, () -> context, registry)
+                .observe(() -> delegate.commitSuccess(item));
+    }
+}

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/pipeline/ObservedIdempotencyGuard.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/pipeline/ObservedIdempotencyGuard.java
@@ -1,0 +1,67 @@
+package com.example.tasktracker.emailsender.o11y.pipeline;
+
+import com.example.tasktracker.emailsender.exception.infrastructure.InfrastructureException;
+import com.example.tasktracker.emailsender.o11y.observation.context.RedisContextFactory;
+import com.example.tasktracker.emailsender.o11y.observation.context.RedisObservationContext;
+import com.example.tasktracker.emailsender.o11y.observation.convention.RedisConvention;
+import com.example.tasktracker.emailsender.pipeline.idempotency.IdempotencyGuard;
+import com.example.tasktracker.emailsender.pipeline.model.PipelineBatch;
+import com.example.tasktracker.emailsender.pipeline.model.PipelineItem;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.script.RedisScript;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class ObservedIdempotencyGuard implements IdempotencyGuard {
+    private final IdempotencyGuard delegate;
+    private final RedisContextFactory contextFactory;
+    private final ObservationRegistry registry;
+    private final String scriptSha1;
+    private final RedisConvention redisConvention;
+
+    private static final String OPERATION_NAME = "EVAL";
+    private static final String LOGICAL_OPERATION_NAME = "idempotency.check";
+
+    public ObservedIdempotencyGuard(IdempotencyGuard delegate,
+                                    RedisContextFactory contextFactory,
+                                    ObservationRegistry registry,
+                                    RedisScript<List<String>> delegateIdempotencyScript,
+                                    RedisConvention redisConvention) {
+        this.delegate = delegate;
+        this.contextFactory = contextFactory;
+        this.registry = registry;
+        this.scriptSha1 = delegateIdempotencyScript.getSha1();
+        this.redisConvention = redisConvention;
+    }
+
+    @Override
+    public void checkAndLock(PipelineBatch batch) throws InfrastructureException {
+        if (batch.items().isEmpty()) return;
+
+        RedisObservationContext context = contextFactory.createContext(
+                OPERATION_NAME,
+                LOGICAL_OPERATION_NAME,
+                batch.items().size(),
+                scriptSha1
+        );
+
+        Observation.createNotStarted(redisConvention, () -> context, registry)
+                .observeChecked(() -> delegate.checkAndLock(batch));
+    }
+
+    @Override
+    public void checkAndLock(PipelineItem item) {
+        RedisObservationContext context = contextFactory.createContext(
+                OPERATION_NAME,
+                LOGICAL_OPERATION_NAME,
+                null,
+                scriptSha1
+        );
+
+        Observation.createNotStarted(redisConvention, () -> context, registry)
+                .observeChecked(() -> delegate.checkAndLock(item));
+    }
+}


### PR DESCRIPTION
Внедрение инструментов мониторинга для уровня дедупликации и операций с Redis через Micrometer Observation:

1. Общая редис конвенция
2. Декораторы ObservedIdempotencyGuard и ObservedIdempotencyCommitter 