### PR TITLE
feat(email-sender): implement SMTP observability

### DIFF
--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/api/email/EmailHeaders.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/api/email/EmailHeaders.java
@@ -2,4 +2,5 @@ package com.example.tasktracker.emailsender.api.email;
 
 public class EmailHeaders {
     public static final String X_CORRELATION_ID = "X-Correlation-ID";
+    public static final String X_TEMPLATE_ID = "X-Template-ID";
 }

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/config/AppProperties.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/config/AppProperties.java
@@ -7,6 +7,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.validation.annotation.Validated;
 
+import java.util.Set;
+
 @Configuration
 @ConfigurationProperties(prefix = "app")
 @Validated
@@ -23,9 +25,19 @@ public class AppProperties {
 
     private ObservationProperties observability = new ObservationProperties();
 
-    @Getter @Setter
+    @Getter
+    @Setter
     public static class ObservationProperties {
         private boolean enabled = true;
         private boolean captureMessageSizes = false;
+
+        private String defaultSmtpProviderName = "default-smtp-provider";
+        /**
+         * Список доменов, которые считаются "крупными".
+         * Только они попадут в теги метрик. Остальные станут "other".
+         */
+        private Set<String> knownDomains = Set.of(
+                "gmail.com", "yahoo.com", "outlook.com", "icloud.com", "yandex.ru", "mail.ru"
+        );
     }
 }

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/context/EmailSendContext.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/context/EmailSendContext.java
@@ -1,0 +1,54 @@
+package com.example.tasktracker.emailsender.o11y.observation.context;
+
+import com.example.tasktracker.emailsender.api.email.EmailHeaders;
+import com.example.tasktracker.emailsender.pipeline.sender.SendInstructions;
+import io.micrometer.observation.transport.Kind;
+import io.micrometer.observation.transport.SenderContext;
+import lombok.Getter;
+
+import java.util.Map;
+import java.util.Objects;
+
+@Getter
+public class EmailSendContext extends SenderContext<Map<String, String>> {
+    public static final String UNKNOWN_VALUE = "unset";
+
+    private final String fromAddress;
+    private final String remoteHost;
+    private final String remotePort;
+    private final String contentType;
+    private final String toDomain;
+
+    public EmailSendContext(SendInstructions instructions,
+                            String from,
+                            String host,
+                            int port,
+                            String toDomain,
+                            boolean isHtml) {
+        super((carrier, key, value) -> {
+            if (carrier != null) {
+                carrier.put(key, value);
+            }
+        }, Kind.CLIENT);
+        this.fromAddress = Objects.requireNonNull(from);
+        this.remoteHost = Objects.requireNonNull(host);
+        this.remotePort = String.valueOf(port);
+        this.toDomain = Objects.requireNonNull(toDomain);
+        this.contentType = isHtml ? "text/html" : "text/plain";
+        setCarrier(instructions.headers());
+    }
+
+    public String getTemplateId() {
+        if (getCarrier() != null) {
+            return getCarrier().getOrDefault(EmailHeaders.X_TEMPLATE_ID, UNKNOWN_VALUE);
+        }
+        return UNKNOWN_VALUE;
+    }
+
+    public String getCorrelationId() {
+        if (getCarrier() != null) {
+            return getCarrier().getOrDefault(EmailHeaders.X_CORRELATION_ID, UNKNOWN_VALUE);
+        }
+        return UNKNOWN_VALUE;
+    }
+}

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/context/SmtpContextFactory.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/context/SmtpContextFactory.java
@@ -1,0 +1,36 @@
+package com.example.tasktracker.emailsender.o11y.observation.context;
+
+
+import com.example.tasktracker.emailsender.o11y.observation.util.EmailTagSanitizer;
+import com.example.tasktracker.emailsender.o11y.observation.util.SmtpProviderResolver;
+import com.example.tasktracker.emailsender.pipeline.sender.SendInstructions;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.mail.MailProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SmtpContextFactory {
+
+    private final MailProperties mailProperties;
+    private final EmailTagSanitizer sanitizer;
+    private final SmtpProviderResolver providerResolver;
+
+    public EmailSendContext createContext(SendInstructions instructions, String senderAddress) {
+
+        String safeDomain = sanitizer.getSafeDomain(instructions.to());
+
+        EmailSendContext context = new EmailSendContext(
+                instructions,
+                senderAddress,
+                mailProperties.getHost(),
+                mailProperties.getPort(),
+                safeDomain,
+                true
+        );
+
+        context.setRemoteServiceName(providerResolver.resolveName(mailProperties.getHost()));
+
+        return context;
+    }
+}

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/convention/EmailSmtpConvention.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/convention/EmailSmtpConvention.java
@@ -1,0 +1,97 @@
+package com.example.tasktracker.emailsender.o11y.observation.convention;
+
+import com.example.tasktracker.emailsender.o11y.observation.context.EmailSendContext;
+import io.micrometer.common.KeyValues;
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.observation.Observation;
+
+public class EmailSmtpConvention extends BaseO11yConvention<EmailSendContext> {
+
+    @Override
+    public KeyValues getLowCardinalityKeyValues(EmailSendContext context) {
+        return super.getLowCardinalityKeyValues(context).and(
+                LowCardinalityTags.FROM_ADDRESS.asString(), context.getFromAddress(),
+                LowCardinalityTags.TO_DOMAIN.asString(), context.getToDomain(),
+                LowCardinalityTags.TEMPLATE_ID.asString(), context.getTemplateId(),
+                LowCardinalityTags.CONTENT_TYPE.asString(), context.getContentType(),
+                LowCardinalityTags.PEER_SERVICE.asString(), context.getRemoteServiceName(),
+                LowCardinalityTags.SERVER_ADDRESS.asString(), context.getRemoteHost(),
+                LowCardinalityTags.SERVER_PORT.asString(), context.getRemotePort()
+        );
+    }
+
+    @Override
+    public KeyValues getHighCardinalityKeyValues(EmailSendContext context) {
+        return super.getHighCardinalityKeyValues(context).
+                and(HighCardinalityTags.CORRELATION_ID.asString(), context.getCorrelationId());
+    }
+
+    @Override
+    public boolean supportsContext(Observation.Context context) {
+        return context.getClass() == EmailSendContext.class;
+    }
+
+    @Override
+    public String getName() {
+        return "email.send.duration";
+    }
+
+    @Override
+    public String getContextualName(EmailSendContext context) {
+        return "email.send";
+    }
+
+    public enum LowCardinalityTags implements KeyName {
+        FROM_ADDRESS {
+            @Override
+            public String asString() {
+                return "email.from.address";
+            }
+        },
+        TO_DOMAIN {
+            @Override
+            public String asString() {
+                return "email.to.domain";
+            }
+        },
+        TEMPLATE_ID {
+            @Override
+            public String asString() {
+                return "email.template.id";
+            }
+        },
+        CONTENT_TYPE {
+            @Override
+            public String asString() {
+                return "email.content_type";
+            }
+        },
+        PEER_SERVICE {
+            @Override
+            public String asString() {
+                return "peer.service";
+            }
+        },
+        SERVER_ADDRESS {
+            @Override
+            public String asString() {
+                return "server.address";
+            }
+        },
+        SERVER_PORT {
+            @Override
+            public String asString() {
+                return "server.port";
+            }
+        }
+    }
+
+    public enum HighCardinalityTags implements KeyName {
+        CORRELATION_ID {
+            @Override
+            public String asString() {
+                return "email.correlation_id";
+            }
+        }
+    }
+}

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/util/EmailTagSanitizer.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/util/EmailTagSanitizer.java
@@ -1,0 +1,22 @@
+package com.example.tasktracker.emailsender.o11y.observation.util;
+
+import com.example.tasktracker.emailsender.config.AppProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class EmailTagSanitizer {
+
+    private final AppProperties properties;
+
+    public String getSafeDomain(String email) {
+        Set<String> knownDomains = properties.getObservability().getKnownDomains();
+        if (email == null || !email.contains("@")) return "invalid";
+
+        String domain = email.substring(email.indexOf("@") + 1).toLowerCase();
+        return knownDomains.contains(domain) ? domain : "other_domain";
+    }
+}

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/util/SmtpProviderResolver.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/util/SmtpProviderResolver.java
@@ -1,0 +1,15 @@
+package com.example.tasktracker.emailsender.o11y.observation.util;
+
+import com.example.tasktracker.emailsender.config.AppProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SmtpProviderResolver {
+    private final AppProperties properties;
+
+    public String resolveName(String host) {
+        return properties.getObservability().getDefaultSmtpProviderName();
+    }
+}

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/util/TelemetryTracker.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/util/TelemetryTracker.java
@@ -1,0 +1,43 @@
+package com.example.tasktracker.emailsender.o11y.observation.util;
+
+import com.example.tasktracker.emailsender.pipeline.model.PipelineItem;
+import com.example.tasktracker.emailsender.util.AsyncUtils;
+import io.micrometer.observation.Observation;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+
+@Slf4j
+public class TelemetryTracker {
+
+    /**
+     * Оборачивает асинхронный вызов в Observation. Обрабатывает исключения и статус PipelineItem.
+     */
+    public CompletableFuture<Void> trackAsync(
+            Observation observation,
+            PipelineItem item,
+            Supplier<CompletableFuture<Void>> action) {
+
+        observation.start();
+
+        try (Observation.Scope ignored = observation.openScope()) {
+            return action.get().whenComplete((result, ex) -> {
+                if (ex != null) {
+                    observation.error(AsyncUtils.unwrap(ex));
+                } else {
+                    reportIfFailed(observation, item);
+                }
+                observation.stop();
+            });
+        } catch (Throwable t) {
+            observation.error(t);
+            observation.stop();
+            return CompletableFuture.failedFuture(t);
+        }
+    }
+
+    private void reportIfFailed(Observation observation, PipelineItem item) {
+        item.getStage().toException().ifPresent(observation::error);
+    }
+}

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/pipeline/ObservedEmailTransport.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/pipeline/ObservedEmailTransport.java
@@ -1,0 +1,29 @@
+package com.example.tasktracker.emailsender.o11y.pipeline;
+
+import com.example.tasktracker.emailsender.config.EmailSenderProperties;
+import com.example.tasktracker.emailsender.o11y.observation.context.EmailSendContext;
+import com.example.tasktracker.emailsender.o11y.observation.context.SmtpContextFactory;
+import com.example.tasktracker.emailsender.o11y.observation.convention.EmailSmtpConvention;
+import com.example.tasktracker.emailsender.pipeline.sender.EmailTransport;
+import com.example.tasktracker.emailsender.pipeline.sender.SendInstructions;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class ObservedEmailTransport implements EmailTransport {
+    private final EmailTransport delegate;
+    private final ObservationRegistry registry;
+    private final EmailSmtpConvention convention;
+    private final SmtpContextFactory contextFactory;
+    private final EmailSenderProperties emailSenderProperties;
+
+    @Override
+    public void send(SendInstructions sendInstructions) {
+        EmailSendContext sendContext =
+                contextFactory.createContext(sendInstructions, emailSenderProperties.getSenderAddress());
+
+        Observation.createNotStarted(convention, () -> sendContext, registry)
+                .observe(() -> delegate.send(sendInstructions));
+    }
+}

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/pipeline/ObservedSender.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/pipeline/ObservedSender.java
@@ -1,0 +1,37 @@
+package com.example.tasktracker.emailsender.o11y.pipeline;
+
+import com.example.tasktracker.emailsender.o11y.observation.context.KafkaContextFactory;
+import com.example.tasktracker.emailsender.o11y.observation.context.kafka.KafkaRecordProcessContext;
+import com.example.tasktracker.emailsender.o11y.observation.convention.KafkaProcessConvention;
+import com.example.tasktracker.emailsender.o11y.observation.util.TelemetryTracker;
+import com.example.tasktracker.emailsender.pipeline.model.PipelineItem;
+import com.example.tasktracker.emailsender.pipeline.sender.Sender;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
+import lombok.RequiredArgsConstructor;
+
+import java.util.concurrent.CompletableFuture;
+
+@RequiredArgsConstructor
+public class ObservedSender implements Sender {
+    private final Sender delegate;
+    private final ObservationRegistry registry;
+    private final KafkaContextFactory recordContextFactory;
+    private final KafkaProcessConvention processConvention;
+    private final TelemetryTracker tracker;
+
+    @Override
+    public CompletableFuture<Void> sendAsync(PipelineItem item) {
+
+        KafkaRecordProcessContext processContext = recordContextFactory.createProcessContext(item);
+
+        Observation processObservation = Observation.createNotStarted(
+                processConvention, () -> processContext, registry);
+
+        return tracker.trackAsync(
+                processObservation,
+                item,
+                () -> delegate.sendAsync(item)
+        );
+    }
+}

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/pipeline/sender/AsyncSender.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/pipeline/sender/AsyncSender.java
@@ -8,7 +8,6 @@ import com.example.tasktracker.emailsender.pipeline.model.RejectReason;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.List;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 
@@ -29,19 +28,6 @@ public class AsyncSender implements Sender {
                         handleError(item, throwable);
                     return result;
                 });
-    }
-
-    @Override
-    public CompletableFuture<Void> sendChunkAsync(List<PipelineItem> chunk) {
-        if (chunk == null || chunk.isEmpty()) {
-            return CompletableFuture.completedFuture(null);
-        }
-
-        List<CompletableFuture<Void>> futures = chunk.stream()
-                .map(this::sendAsync)
-                .toList();
-
-        return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
     }
 
     private void handleError(PipelineItem item, Throwable t) {

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/pipeline/sender/ResilientSmtpEmailClient.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/pipeline/sender/ResilientSmtpEmailClient.java
@@ -1,5 +1,6 @@
 package com.example.tasktracker.emailsender.pipeline.sender;
 
+import com.example.tasktracker.emailsender.api.email.EmailHeaders;
 import com.example.tasktracker.emailsender.api.messaging.TriggerCommand;
 import com.example.tasktracker.emailsender.exception.FatalProcessingException;
 import com.example.tasktracker.emailsender.exception.RetryableProcessingException;
@@ -13,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
+import java.util.HashMap;
 import java.util.concurrent.*;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -100,12 +102,16 @@ public class ResilientSmtpEmailClient implements EmailClient {
                             sendCommand.localeTag()
                     );
 
+                    HashMap<String, String> headers = new HashMap<>();
+                    headers.put(EmailHeaders.X_CORRELATION_ID, sendCommand.correlationId());
+                    headers.put(EmailHeaders.X_TEMPLATE_ID, sendCommand.templateId());
+
                     transport.send(new SendInstructions(
                             sendCommand.recipientEmail(),
                             renderingResult.subject(),
                             renderingResult.body(),
                             true,
-                            sendCommand.correlationId()
+                            headers
                     ));
 
                 },

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/pipeline/sender/SendInstructions.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/pipeline/sender/SendInstructions.java
@@ -1,4 +1,16 @@
 package com.example.tasktracker.emailsender.pipeline.sender;
 
-public record SendInstructions(String to, String subject, String body, boolean isHtml, String correlationId) {
+import java.util.HashMap;
+import java.util.Map;
+
+public record SendInstructions(
+        String to,
+        String subject,
+        String body,
+        boolean isHtml,
+        Map<String, String> headers
+) {
+    public SendInstructions {
+        headers = headers == null ? new HashMap<>() : new HashMap<>(headers);
+    }
 }

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/pipeline/sender/Sender.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/pipeline/sender/Sender.java
@@ -25,6 +25,7 @@ public interface Sender {
      * @return Фьюча, сигнализирующая о завершении логической обработки элемента.
      */
     CompletableFuture<Void> sendAsync(PipelineItem item);
+
     /**
      * Группирует список элементов в единый асинхронный чанк.
      * <p>
@@ -34,6 +35,16 @@ public interface Sender {
      * @param chunk Список элементов для параллельной обработки.
      * @return Фьюча, представляющая собой завершение обработки всего чанка.
      */
-    CompletableFuture<Void> sendChunkAsync(List<PipelineItem> chunk);
+    default CompletableFuture<Void> sendChunkAsync(List<PipelineItem> chunk) {
+        if (chunk == null || chunk.isEmpty()) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        List<CompletableFuture<Void>> futures = chunk.stream()
+                .map(this::sendAsync)
+                .toList();
+
+        return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+    }
 
 }

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/pipeline/sender/SmtpEmailTransport.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/pipeline/sender/SmtpEmailTransport.java
@@ -15,14 +15,10 @@ import org.springframework.stereotype.Component;
 
 import java.nio.charset.StandardCharsets;
 
-import static com.example.tasktracker.emailsender.api.email.EmailHeaders.X_CORRELATION_ID;
-
 @Component
 @RequiredArgsConstructor
 @Slf4j
 public class SmtpEmailTransport implements EmailTransport {
-
-
     private final JavaMailSender mailSender;
     private final EmailSenderProperties properties;
     private final EmailErrorResolver emailErrorResolver;
@@ -43,7 +39,8 @@ public class SmtpEmailTransport implements EmailTransport {
         }
     }
 
-    @NonNull MimeMessage createMimeMessage(SendInstructions instructions) throws MessagingException {
+    @NonNull
+    MimeMessage createMimeMessage(SendInstructions instructions) throws MessagingException {
         MimeMessage mimeMessage = mailSender.createMimeMessage();
         MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, true, StandardCharsets.UTF_8.name());
 
@@ -52,7 +49,13 @@ public class SmtpEmailTransport implements EmailTransport {
         helper.setSubject(instructions.subject());
         helper.setText(instructions.body(), instructions.isHtml());
 
-        mimeMessage.addHeader(X_CORRELATION_ID, instructions.correlationId());
+        instructions.headers().forEach((k, v) -> {
+            try {
+                mimeMessage.addHeader(k, v);
+            } catch (MessagingException e) {
+                log.warn("Failed to set header: {}", k);
+            }
+        });
 
         return mimeMessage;
     }

--- a/task-tracker-email-sender/src/test/java/com/example/tasktracker/emailsender/pipeline/sender/SmtpEmailTransportTest.java
+++ b/task-tracker-email-sender/src/test/java/com/example/tasktracker/emailsender/pipeline/sender/SmtpEmailTransportTest.java
@@ -1,5 +1,6 @@
 package com.example.tasktracker.emailsender.pipeline.sender;
 
+import com.example.tasktracker.emailsender.api.email.EmailHeaders;
 import com.example.tasktracker.emailsender.config.EmailSenderProperties;
 import jakarta.mail.Session;
 import jakarta.mail.internet.MimeMessage;
@@ -8,6 +9,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.HashMap;
 
 import static com.example.tasktracker.emailsender.api.email.EmailHeaders.X_CORRELATION_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -23,7 +26,7 @@ class SmtpEmailTransportTest {
     @BeforeEach
     void setUp() {
         mimeMessage = new MimeMessage((Session) null);
-        mailSender = new JavaMailSenderImpl(){
+        mailSender = new JavaMailSenderImpl() {
             @Override
             public MimeMessage createMimeMessage() {
                 return mimeMessage;
@@ -43,13 +46,17 @@ class SmtpEmailTransportTest {
 
     @Test
     void shouldAddCorrelationIdToMimeHeaders() throws Exception {
+        String corrId = "corr-123";
+
+        HashMap<String, String> headers = new HashMap<>();
+        headers.put(EmailHeaders.X_CORRELATION_ID, corrId);
         var instructions = new SendInstructions(
-                "test@test.com", "Subject", "Body", true, "corr-123"
+                "test@test.com", "Subject", "Body", true, headers
         );
 
         transport.send(instructions);
 
-        String header = mimeMessage.getHeader(X_CORRELATION_ID, null);
-        assertEquals("corr-123", header, "X-Correlation-ID header must be present in MimeMessage");
+        String corrHeader = mimeMessage.getHeader(X_CORRELATION_ID, null);
+        assertEquals(corrId, corrHeader, "X-Correlation-ID header must be present in MimeMessage");
     }
 }


### PR DESCRIPTION
Этот PR делает процесс отправки сообщений полностью прозрачным для систем мониторинга и стандартизирует передачу метаданных через протокол SMTP:

1. Стандартизация хэдеров: перенос X-Template-ID и X-Correlation-ID в заголовки письма.
2. Сквозной мониторинг: Связали Trace ID из Kafka с заголовками исходящих писем.
3. Профилирование SMTP: Внедрены метрики описывающие внешний провайдер.
4. Безопасная аналитика: Мы внедрили EmailTagSanitizer, который группирует редкие почтовые домены в категорию other, обеспечивая низкую кардинальность.