### PR TITLE
fix(o11y): precision peer name propagation and email span naming clarifying

### DIFF
--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/context/KafkaContextFactory.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/context/KafkaContextFactory.java
@@ -51,6 +51,7 @@ public class KafkaContextFactory {
                 records.getFirst().topic();
 
         fillConnectionDetails(context, topic);
+        context.setRemoteServiceName(resolver.getRemoteServiceName());
 
         context.setBatchSize(records.size());
 
@@ -79,6 +80,8 @@ public class KafkaContextFactory {
                 () -> context.setConversationId("unset"));
         context.setPartition(String.valueOf(record.partition()));
         context.setOffset(String.valueOf(record.offset()));
+
+        context.setRemoteServiceName(resolver.getRemoteServiceName());
 
         if (doCaptureSizes) {
             context.setBodySize(calculateBodySize(record));
@@ -142,8 +145,8 @@ public class KafkaContextFactory {
     }
 
     public <T extends KafkaRecordPublishContext> T createPublishContext(ProducerRecord<byte[], byte[]> record,
-                                                                        Supplier<T> contextSupplier,
-                                                                        BiConsumer<T, ProducerRecord<byte[], byte[]>> dataEnhancer) {
+                                                                                                                        Supplier<T> contextSupplier,
+                                                                                                                        BiConsumer<T, ProducerRecord<byte[], byte[]>> dataEnhancer) {
         T context = contextSupplier.get();
 
         context.setCarrier(record);
@@ -157,6 +160,8 @@ public class KafkaContextFactory {
                 () -> context.setConversationId("unset"));
 
         context.setTopic(record.topic());
+
+        context.setRemoteServiceName(resolver.getRemoteServiceName());
 
         if (doCaptureSizes) {
             context.setBodySize(calculateBodySize(record));
@@ -181,6 +186,7 @@ public class KafkaContextFactory {
         context.setServerAddress(resolver.getServerAddress());
         context.setServerPort(resolver.getServerPort());
         context.setTopic(topic);
+
     }
 
 // --- Счётчики байтов ---

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/context/RedisContextFactory.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/context/RedisContextFactory.java
@@ -29,7 +29,7 @@ public class RedisContextFactory {
                 redisPropertiesResolver.getDatabaseIndex()
         );
 
-        context.setRemoteServiceName("redis");
+        context.setRemoteServiceName(redisPropertiesResolver.getAddress());
 
         if (batchSize != null) context.setBatchSize(batchSize);
         if (scriptSha1 != null) context.setScriptSha1(scriptSha1);

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/convention/EmailSmtpConvention.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/convention/EmailSmtpConvention.java
@@ -38,7 +38,7 @@ public class EmailSmtpConvention extends BaseO11yConvention<EmailSendContext> {
 
     @Override
     public String getContextualName(EmailSendContext context) {
-        return "email.send";
+        return context.getTemplateId() + " send";
     }
 
     public enum LowCardinalityTags implements KeyName {

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/util/KafkaPropertiesResolver.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/o11y/observation/util/KafkaPropertiesResolver.java
@@ -28,6 +28,9 @@ public class KafkaPropertiesResolver {
     private final String serverAddress;
 
     @Getter
+    private final String remoteServiceName;
+
+    @Getter
     private final int serverPort;
 
     public KafkaPropertiesResolver(
@@ -47,6 +50,8 @@ public class KafkaPropertiesResolver {
         ServerEndpoint endpoint = determineServerEndpoint(bootstrapServers);
         this.serverAddress = endpoint.host();
         this.serverPort = endpoint.port();
+
+        this.remoteServiceName = serverAddress;
     }
 
     private String determineClientId(KafkaProperties props, String appName, String instanceId) {
@@ -118,5 +123,6 @@ public class KafkaPropertiesResolver {
         return new ServerEndpoint(host, port);
     }
 
-    private record ServerEndpoint(String host, int port) {}
+    private record ServerEndpoint(String host, int port) {
+    }
 }

--- a/task-tracker-email-sender/src/main/resources/application.yml
+++ b/task-tracker-email-sender/src/main/resources/application.yml
@@ -37,6 +37,11 @@ spring:
     username: ""
     password: ""
 
+  data:
+    redis:
+      host: task-tracker-redis
+      port: 6379
+
   kafka:
     bootstrap-servers: task-tracker-kafka:9092
     consumer:


### PR DESCRIPTION
Данный PR вносит правки в слой обсервабилити для обеспечения консистентности имен спанов и более точной идентификации инфраструктурных узлов в трейсах:

1. Имя спана в EmailSmtpConvention изменено на {templateId} send с целью приближения к идеологии otel semconv: "{destination} {operation}";
2. Добавлена проброска remoteServiceName для всех типов контекстов с целью идентификации сервисов по универсальному признаку.