### PR TITLE
test(backend): add "chaos" endpoint to trigger random 500 errors

### DIFF
--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/security/config/SecurityConfig.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/security/config/SecurityConfig.java
@@ -106,7 +106,8 @@ public class SecurityConfig {
             new AntPathRequestMatcher("/swagger-ui.html"),
             new AntPathRequestMatcher("/swagger-ui/**"),
             new AntPathRequestMatcher("/v3/api-docs/**"),
-            new AntPathRequestMatcher("/actuator/health/**")
+            new AntPathRequestMatcher("/actuator/health/**"),
+            new AntPathRequestMatcher("/api/v1/throw")
     );
 
     /**

--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/web/ErrorThrowController.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/web/ErrorThrowController.java
@@ -1,0 +1,25 @@
+package com.example.tasktracker.backend.web;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Random;
+
+@RestController
+@RequestMapping("/api/v1/throw")
+public class ErrorThrowController {
+    Random rnd = new Random();
+    RuntimeException[] errs = new RuntimeException[]{
+            new UnsupportedOperationException(),
+            new IllegalStateException(),
+            new NullPointerException(),
+            new IllegalArgumentException(),
+            new UnsupportedOperationException()};
+
+    @GetMapping()
+    public String generateException() {
+        int i = rnd.nextInt(errs.length);
+        throw errs[i];
+    }
+}


### PR DESCRIPTION
Этот PR добавляет вспомогательный контроллер для генерации «шума» и проверки корректности отображения ошибок.
