### PR TITLE
feat(o11y): optimize HikariCP metrics and add clean C2 dashboard

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -233,7 +233,6 @@ services:
     image: grafana/grafana:12.0.0
     container_name: task-tracker-grafana
     volumes:
-      - grafana_data:/var/lib/grafana
       - ./observability/grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards
       - ./observability/grafana/provisioning/datasources:/etc/grafana/provisioning/datasources
     environment:
@@ -296,7 +295,6 @@ volumes:
   pgdata:
   kafkadata:
   prometheus_data:
-  grafana_data:
   tempo_data:
   loki_data:
 

--- a/observability/grafana/provisioning/dashboards/HikariCP.json
+++ b/observability/grafana/provisioning/dashboards/HikariCP.json
@@ -1,0 +1,288 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 1,
+  "links": [],
+  "panels": [
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "expr": "sum(hikaricp_connections_max{exported_job=~\"$service_type\", exported_instance=~\"$instance\"}) by (pool)",
+          "legendFormat": "Max",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(hikaricp_connections_active{exported_job=~\"$service_type\", exported_instance=~\"$instance\"}) by (pool)",
+          "legendFormat": "Active",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(hikaricp_connections_idle{exported_job=~\"$service_type\", exported_instance=~\"$instance\"}) by (pool)",
+          "legendFormat": "Idle",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(hikaricp_connections_pending{exported_job=~\"$service_type\", exported_instance=~\"$instance\"}) by (pool)",
+          "legendFormat": "Pending",
+          "refId": "D"
+        }
+      ],
+      "title": "Usage",
+      "type": "timeseries"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(hikaricp_connections_acquire_seconds_bucket{exported_job=~\"$service_type\", exported_instance=~\"$instance\"}[$__rate_interval])) by (le)) * 1000",
+          "legendFormat": "p99",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(hikaricp_connections_acquire_seconds_bucket{exported_job=~\"$service_type\", exported_instance=~\"$instance\"}[$__rate_interval])) by (le)) * 1000",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(increase(hikaricp_connections_timeout_total{exported_job=~\"$service_type\", exported_instance=~\"$instance\"}[5m]))",
+          "legendFormat": "Timeouts",
+          "refId": "C"
+        }
+      ],
+      "title": "Latency",
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "schemaVersion": 41,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "task-tracker-backend",
+          "value": "task-tracker-backend"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus_ds"
+        },
+        "definition": "label_values(hikaricp_connections_max, exported_job)",
+        "includeAll": false,
+        "name": "service_type",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(hikaricp_connections_max, exported_job)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus_ds"
+        },
+        "definition": "label_values(hikaricp_connections_max{exported_job=\"$service_type\"}, exported_instance)",
+        "includeAll": true,
+        "multi": true,
+        "name": "instance",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(hikaricp_connections_max{exported_job=\"$service_type\"}, exported_instance)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-7d",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "utc",
+  "title": "HikariCP",
+  "uid": "hikaricp-c2",
+  "version": 1
+}

--- a/task-tracker-backend/pom.xml
+++ b/task-tracker-backend/pom.xml
@@ -24,10 +24,6 @@
 			<artifactId>lombok</artifactId>
 			<optional>true</optional>
 		</dependency>
-		<dependency>
-			<groupId>io.micrometer</groupId>
-			<artifactId>micrometer-registry-otlp</artifactId>
-		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/task-tracker-backend/src/main/java/com/example/tasktracker/backend/config/MetricsConfig.java
+++ b/task-tracker-backend/src/main/java/com/example/tasktracker/backend/config/MetricsConfig.java
@@ -1,0 +1,41 @@
+package com.example.tasktracker.backend.config;
+
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
+import io.opentelemetry.sdk.metrics.Aggregation;
+import io.opentelemetry.sdk.metrics.InstrumentSelector;
+import io.opentelemetry.sdk.metrics.View;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Arrays;
+
+@Configuration
+public class MetricsConfig {
+    @Bean
+    public AutoConfigurationCustomizerProvider otelMetricsCustomizer() {
+        return autoConfiguration -> autoConfiguration.addMeterProviderCustomizer(
+                (sdkMeterProviderBuilder, configProperties) -> sdkMeterProviderBuilder.registerView(
+                        InstrumentSelector.builder()
+                                .setName("hikaricp.connections.acquire")
+                                .build(),
+                        View.builder()
+                                .setAggregation(
+                                        Aggregation.explicitBucketHistogram(
+                                                Arrays.asList(
+                                                        0.001, // 1мс
+                                                        0.005, // 5мс
+                                                        0.010, // 10мс
+                                                        0.050, // 50мс
+                                                        0.100, // 100мс
+                                                        0.250, // 250мс
+                                                        0.500, // 500мс
+                                                        1.000, // 1с
+                                                        5.000  // 5с
+                                                )
+                                        )
+                                )
+                                .build()
+                )
+        );
+    }
+}


### PR DESCRIPTION
мониторинг исторических данных использования пула и задержек
нарезаны бакеты hikaricp.connections.acquire для гистограмм дашборда
функциональность micrometer-registry-otlp свелась лишь к дублированию метрик - убран.