### PR TITLE
refactor(scheduler): simplify callback execution and fix consumer group override

### DIFF
--- a/task-tracker-scheduler/src/main/java/com/example/tasktracker/scheduler/config/AppConfig.java
+++ b/task-tracker-scheduler/src/main/java/com/example/tasktracker/scheduler/config/AppConfig.java
@@ -1,56 +1,10 @@
 package com.example.tasktracker.scheduler.config;
 
-import com.example.tasktracker.scheduler.common.MdcTaskDecorator;
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics;
-import io.opentelemetry.context.Context;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
-
-import java.util.List;
-import java.util.concurrent.Executor;
 
 @Configuration
 @Slf4j
 @EnableConfigurationProperties(EmailPublishingProperties.class)
-public class AppConfig {
-
-    public static final String KAFKA_CALLBACK_EXECUTOR = "kafkaCallbackExecutor";
-
-    /**
-     * Создает Executor для обработки асинхронных коллбэков от KafkaTemplate.
-     * Этот Executor "знает" про MDC и пробрасывает его в потоки коллбэков.
-     */
-    @Bean(name = KAFKA_CALLBACK_EXECUTOR)
-    public Executor kafkaCallbackExecutor(MeterRegistry meterRegistry) {
-        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        int availableProcessors = Runtime.getRuntime().availableProcessors();
-
-        int corePoolSize = Math.max(2, availableProcessors);
-        int maxPoolSize = Math.max(corePoolSize, availableProcessors * 2);
-
-        executor.setCorePoolSize(corePoolSize);
-        executor.setMaxPoolSize(maxPoolSize);
-        executor.setQueueCapacity(500);
-        executor.setThreadNamePrefix("kafka-cb-");
-
-        executor.setTaskDecorator(new MdcTaskDecorator());
-
-        executor.setWaitForTasksToCompleteOnShutdown(true);
-        executor.setAwaitTerminationSeconds(10);
-        executor.initialize();
-
-        new ExecutorServiceMetrics(
-                executor.getThreadPoolExecutor(),
-                KAFKA_CALLBACK_EXECUTOR,
-                List.of()
-        ).bindTo(meterRegistry);
-
-        log.info("Kafka Callback Executor initialized. Core: {}, Max: {}", corePoolSize, maxPoolSize);
-
-        return Context.taskWrapping(executor);
-    }
-}
+public class AppConfig {}

--- a/task-tracker-scheduler/src/main/java/com/example/tasktracker/scheduler/consumer/dailyreport/DailyTaskReportConsumer.java
+++ b/task-tracker-scheduler/src/main/java/com/example/tasktracker/scheduler/consumer/dailyreport/DailyTaskReportConsumer.java
@@ -36,7 +36,6 @@ public class DailyTaskReportConsumer {
     private record JobRunKey(String jobRunId, LocalDate reportDate) {}
 
     @KafkaListener(
-            id = "daily-report-consumer",
             topics = "${app.scheduler.consumers.daily-report.topic-name}",
             containerFactory = "dailyReportBatchContainerFactory"
     )

--- a/task-tracker-scheduler/src/main/java/com/example/tasktracker/scheduler/job/dailyreport/DailyTaskReportProducerJob.java
+++ b/task-tracker-scheduler/src/main/java/com/example/tasktracker/scheduler/job/dailyreport/DailyTaskReportProducerJob.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -51,7 +50,6 @@ public class DailyTaskReportProducerJob {
     private final JobStateRepository jobStateRepository;
     private final UserIdsFetcherClient userIdsFetcherClient;
     private final KafkaTemplate<String, UserSelectedForDailyReportEvent> kafkaTemplate;
-    private final Executor kafkaCallbackExecutor;
     private final DailyReportJobProperties jobProperties;
     private final String producerTopicName;
     private final MetricsReporter metrics;
@@ -65,13 +63,11 @@ public class DailyTaskReportProducerJob {
     public DailyTaskReportProducerJob(JobStateRepository jobStateRepository,
                                       UserIdsFetcherClient userIdsFetcherClient,
                                       KafkaTemplate<String, UserSelectedForDailyReportEvent> kafkaTemplate,
-                                      Executor kafkaCallbackExecutor,
                                       DailyReportJobProperties jobProperties,
                                       MetricsReporter metrics) {
         this.jobStateRepository = jobStateRepository;
         this.userIdsFetcherClient = userIdsFetcherClient;
         this.kafkaTemplate = kafkaTemplate;
-        this.kafkaCallbackExecutor = kafkaCallbackExecutor;
         this.jobProperties = jobProperties;
         this.producerTopicName = jobProperties.getKafkaTopicName();
         this.metrics = metrics;
@@ -139,8 +135,7 @@ public class DailyTaskReportProducerJob {
                 log.error("Job '{}' for report date {} failed critically. It will be retried on the next schedule.",
                         jobName, reportDate, e);
                 // НЕ сохраняем JobStatus.FAILED, чтобы разрешить автоматический ретрай при следующем запуске по cron.
-            }
-            finally {
+            } finally {
                 Tags finalTags = Tags.of("job_name", jobName, "status", finalStatus);
                 sample.stop(metrics.getTimer(Metric.JOB_RUN_DURATION, finalTags));
             }
@@ -183,7 +178,7 @@ public class DailyTaskReportProducerJob {
                     UserSelectedForDailyReportEvent event =
                             new UserSelectedForDailyReportEvent(userId, jobRunId, reportDate);
                     return kafkaTemplate.send(producerTopicName, event)
-                            .whenCompleteAsync((result, ex) -> {
+                            .whenComplete((result, ex) -> {
                                 if (ex != null) {
                                     hasFailures.set(true);
                                     metrics.incrementCounter(Metric.JOB_KAFKA_SEND_FAILURE, Tags.of("job_name", jobName));
@@ -192,7 +187,7 @@ public class DailyTaskReportProducerJob {
                                 } else {
                                     successCount.incrementAndGet();
                                 }
-                            }, kafkaCallbackExecutor);
+                            });
                 })
                 .map(f -> f.<Void>thenApply(res -> null))
                 .toList();

--- a/task-tracker-scheduler/src/main/java/com/example/tasktracker/scheduler/job/dailyreport/config/DailyReportJobConfiguration.java
+++ b/task-tracker-scheduler/src/main/java/com/example/tasktracker/scheduler/job/dailyreport/config/DailyReportJobConfiguration.java
@@ -1,6 +1,5 @@
 package com.example.tasktracker.scheduler.job.dailyreport.config;
 
-import com.example.tasktracker.scheduler.config.AppConfig;
 import com.example.tasktracker.scheduler.job.JobStateRepository;
 import com.example.tasktracker.scheduler.job.dailyreport.DailyTaskReportJobTrigger;
 import com.example.tasktracker.scheduler.job.dailyreport.DailyTaskReportProducerJob;
@@ -8,14 +7,12 @@ import com.example.tasktracker.scheduler.job.dailyreport.client.UserIdsFetcherCl
 import com.example.tasktracker.scheduler.job.dailyreport.messaging.event.UserSelectedForDailyReportEvent;
 import com.example.tasktracker.scheduler.metrics.MetricsReporter;
 import net.javacrumbs.shedlock.core.LockingTaskExecutor;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.core.KafkaTemplate;
 
 import java.time.Clock;
-import java.util.concurrent.Executor;
 
 @Configuration
 @ConditionalOnProperty(name = "app.scheduler.jobs.daily-task-reports.enabled", havingValue = "true", matchIfMissing = true)
@@ -26,13 +23,11 @@ public class DailyReportJobConfiguration {
             JobStateRepository jobStateRepository,
             UserIdsFetcherClient userIdsFetcherClient,
             KafkaTemplate<String, UserSelectedForDailyReportEvent> kafkaTemplate,
-            @Qualifier(AppConfig.KAFKA_CALLBACK_EXECUTOR) Executor kafkaCallbackExecutor,
             DailyReportJobProperties jobProperties,
             MetricsReporter metrics) {
         return new DailyTaskReportProducerJob(jobStateRepository,
                 userIdsFetcherClient,
                 kafkaTemplate,
-                kafkaCallbackExecutor,
                 jobProperties,
                 metrics);
     }

--- a/task-tracker-scheduler/src/main/resources/application.yml
+++ b/task-tracker-scheduler/src/main/resources/application.yml
@@ -107,7 +107,8 @@ app:
       daily-report:
         enabled: true
         topic-name: "task_tracker.scheduler.events.user_selected_for_report"
-        sink-topic-name: "task_tracker.reporting.events.daily_report_generated"
+#        sink-topic-name: "task_tracker.reporting.events.daily_report_generated"
+        sink-topic-name: "task_tracker.notifications.email_commands"
         group-id: "scheduler-daily-report-group"
         concurrency: 3
         max-poll-records: 500

--- a/task-tracker-scheduler/src/test/java/com/example/tasktracker/scheduler/job/dailyreport/DailyTaskReportProducerJobTest.java
+++ b/task-tracker-scheduler/src/test/java/com/example/tasktracker/scheduler/job/dailyreport/DailyTaskReportProducerJobTest.java
@@ -1,13 +1,13 @@
 package com.example.tasktracker.scheduler.job.dailyreport;
 
 import com.example.tasktracker.scheduler.client.dto.PageInfo;
-import com.example.tasktracker.scheduler.job.JobStateRepository;
-import com.example.tasktracker.scheduler.job.dto.JobExecutionState;
 import com.example.tasktracker.scheduler.config.SchedulerAppProperties;
+import com.example.tasktracker.scheduler.job.JobStateRepository;
 import com.example.tasktracker.scheduler.job.dailyreport.client.UserIdsFetcherClient;
 import com.example.tasktracker.scheduler.job.dailyreport.client.dto.PaginatedUserIdsResponse;
 import com.example.tasktracker.scheduler.job.dailyreport.config.DailyReportJobProperties;
 import com.example.tasktracker.scheduler.job.dailyreport.messaging.event.UserSelectedForDailyReportEvent;
+import com.example.tasktracker.scheduler.job.dto.JobExecutionState;
 import com.example.tasktracker.scheduler.metrics.Metric;
 import com.example.tasktracker.scheduler.metrics.MetricsReporter;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -29,7 +29,6 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -43,7 +42,6 @@ class DailyTaskReportProducerJobTest {
     @Mock private JobStateRepository mockJobStateRepository;
     @Mock private UserIdsFetcherClient mockUserIdsFetcherClient;
     @Mock private KafkaTemplate<String, UserSelectedForDailyReportEvent> mockKafkaTemplate;
-    @Mock private Executor mockKafkaCallbackExecutor;
     @Mock private DailyReportJobProperties mockJobProperties;
     @Mock private Timer mockTimer;
     @Mock private MetricsReporter mockMetrics;
@@ -69,17 +67,10 @@ class DailyTaskReportProducerJobTest {
 
         when(mockMetrics.getTimer(any(), any())).thenReturn(mockTimer);
 
-        doAnswer(invocation -> {
-            Runnable r = invocation.getArgument(0);
-            r.run();
-            return null;
-        }).when(mockKafkaCallbackExecutor).execute(any(Runnable.class));
-
         job = new DailyTaskReportProducerJob(
                 mockJobStateRepository,
                 mockUserIdsFetcherClient,
                 mockKafkaTemplate,
-                mockKafkaCallbackExecutor,
                 mockJobProperties,
                 mockMetrics
         );


### PR DESCRIPTION
Удалена асинхронность обработки результатов записи в кафку. Тред-пул для инкремента счетчика избыточен, это можно сделать в вызывающем треде. Устранены риски рассинхрона конфига и реджекта задач из очереди экзекьютора.
Хардкод ID лисенер-контейнера приводил к оверрайду и бессмысленности параметра конфига daily-report#group-id.
Указан валидный синк-топик в рамках подготовки системы к эксплуатации.