### PR TITLE
feat(email-sender): implement SMTP connection pool via Commons Pool 2

### DIFF
--- a/task-tracker-email-sender/pom.xml
+++ b/task-tracker-email-sender/pom.xml
@@ -58,6 +58,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-pool2</artifactId>
+            <version>2.13.1</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.bucket4j</groupId>
             <artifactId>bucket4j_jdk17-core</artifactId>
             <version>${bucket4j.version}</version>

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/config/PipelineO11yWiringConfig.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/config/PipelineO11yWiringConfig.java
@@ -18,6 +18,7 @@ import io.github.bucket4j.BlockingBucket;
 import io.micrometer.observation.ObservationRegistry;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.mail.MailProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -25,6 +26,7 @@ import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.mail.javamail.JavaMailSender;
 
 import java.util.List;
+import java.util.Properties;
 
 @Configuration
 public class PipelineO11yWiringConfig {
@@ -36,9 +38,12 @@ public class PipelineO11yWiringConfig {
             ObservationRegistry registry,
             EmailSmtpConvention smtpConvention,
             SmtpContextFactory smtpContextFactory,
-            EmailSenderProperties emailSenderProperties
+            EmailSenderProperties emailSenderProperties,
+            MailProperties mailProperties,
+            ReliabilityProperties reliabilityProperties
     ) {
-        EmailTransport delegate = smtpEmailTransport(javaMailSender, emailSenderProperties, emailErrorResolver);
+        EmailTransport delegate =
+                smtpEmailTransport(javaMailSender, emailSenderProperties, emailErrorResolver, mailProperties, reliabilityProperties);
         return new ObservedEmailTransport(
                 delegate,
                 registry,
@@ -52,14 +57,24 @@ public class PipelineO11yWiringConfig {
     @ConditionalOnProperty(value = "app.observation.enabled", havingValue = "false")
     public EmailTransport rawEmailTransport(JavaMailSender javaMailSender,
                                             EmailSenderProperties emailSenderProperties,
-                                            EmailErrorResolver emailErrorResolver) {
-        return smtpEmailTransport(javaMailSender, emailSenderProperties, emailErrorResolver);
+                                            EmailErrorResolver emailErrorResolver,
+                                            MailProperties mailProperties,
+                                            ReliabilityProperties reliabilityProperties) {
+
+        return smtpEmailTransport(javaMailSender, emailSenderProperties, emailErrorResolver, mailProperties, reliabilityProperties);
     }
 
-    public SmtpEmailTransport smtpEmailTransport(JavaMailSender javaMailSender,
+    public EmailTransport smtpEmailTransport(JavaMailSender javaMailSender,
                                              EmailSenderProperties emailSenderProperties,
-                                             EmailErrorResolver emailErrorResolver) {
-        return new SmtpEmailTransport(javaMailSender, emailSenderProperties, emailErrorResolver);
+                                             EmailErrorResolver emailErrorResolver,
+                                             MailProperties mailProperties,
+                                             ReliabilityProperties reliabilityProperties) {
+        SmtpEmailTransport baseTransport = new SmtpEmailTransport(javaMailSender, emailSenderProperties, emailErrorResolver);
+        Properties javamailProperties = ((org.springframework.mail.javamail.JavaMailSenderImpl) javaMailSender).getJavaMailProperties();
+
+        SmtpTransportFactory factory = new SmtpTransportFactory(mailProperties, javamailProperties);
+
+        return new PooledEmailTransport(baseTransport, factory, reliabilityProperties, emailErrorResolver);
     }
 
     @Bean

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/pipeline/sender/EmailErrorResolver.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/pipeline/sender/EmailErrorResolver.java
@@ -45,7 +45,14 @@ public class EmailErrorResolver {
             log.debug("Fatal data/template error: {}.", t.getMessage());
             return new FatalProcessingException(RejectReason.INVALID_PAYLOAD, "Email content preparation failed", t);
         }
-        if (t instanceof MessagingException) {
+        if (t instanceof MessagingException me) {
+            Throwable cause = me.getCause();
+
+            if (cause instanceof java.net.SocketTimeoutException || cause instanceof java.net.SocketException) {
+                log.debug("Temporary SMTP socket timeout during transport operation.");
+                return new InfrastructureException("SMTP socket timeout during transport operation", t);
+            }
+
             log.debug("Exception during message preparation: {}. ", t.getMessage());
             return new FatalProcessingException(RejectReason.INVALID_PAYLOAD, "MIME message creation failed", t);
         }

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/pipeline/sender/PooledEmailTransport.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/pipeline/sender/PooledEmailTransport.java
@@ -1,0 +1,65 @@
+package com.example.tasktracker.emailsender.pipeline.sender;
+
+import com.example.tasktracker.emailsender.config.ReliabilityProperties;
+import jakarta.mail.Transport;
+import jakarta.mail.internet.MimeMessage;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.pool2.impl.GenericObjectPool;
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+
+import java.time.Duration;
+
+@Slf4j
+public class PooledEmailTransport implements EmailTransport {
+
+    private final GenericObjectPool<Transport> pool;
+    private final SmtpEmailTransport delegate;
+    private final EmailErrorResolver errorResolver;
+
+    public PooledEmailTransport(SmtpEmailTransport delegate,
+                                SmtpTransportFactory factory,
+                                ReliabilityProperties properties,
+                                EmailErrorResolver errorResolver) {
+        this.delegate = delegate;
+        this.errorResolver = errorResolver;
+
+        int maxConnections = properties.getCapacity().getMaxActiveConnections();
+
+        GenericObjectPoolConfig<Transport> config = new GenericObjectPoolConfig<>();
+        config.setMaxTotal(maxConnections);
+        config.setMaxIdle(maxConnections);
+        config.setMinIdle(5);
+        config.setTestOnBorrow(true);
+        config.setTestOnReturn(false);
+
+        config.setBlockWhenExhausted(true);
+        config.setMaxWait(Duration.ofSeconds(2));
+
+        this.pool = new GenericObjectPool<>(factory, config);
+    }
+
+    @Override
+    public void send(SendInstructions instructions) {
+        Transport transport = null;
+        try {
+            transport = pool.borrowObject();
+
+            MimeMessage mimeMessage = delegate.createMimeMessage(instructions);
+            mimeMessage.saveChanges();
+
+            transport.sendMessage(mimeMessage, mimeMessage.getAllRecipients());
+
+            pool.returnObject(transport);
+
+        } catch (Exception e) {
+            if (transport != null) {
+                try {
+                    pool.invalidateObject(transport);
+                } catch (Exception ex) {
+                    log.error("Failed to invalidate SMTP transport in pool", ex);
+                }
+            }
+            throw errorResolver.resolve(e);
+        }
+    }
+}

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/pipeline/sender/SmtpTransportFactory.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/pipeline/sender/SmtpTransportFactory.java
@@ -1,0 +1,49 @@
+package com.example.tasktracker.emailsender.pipeline.sender;
+
+import jakarta.mail.Session;
+import jakarta.mail.Transport;
+import org.apache.commons.pool2.BasePooledObjectFactory;
+import org.apache.commons.pool2.PooledObject;
+import org.apache.commons.pool2.impl.DefaultPooledObject;
+import org.springframework.boot.autoconfigure.mail.MailProperties;
+
+import java.util.Properties;
+
+public class SmtpTransportFactory extends BasePooledObjectFactory<Transport> {
+
+    private final MailProperties mailProperties;
+    private final Properties javamailProperties;
+
+    public SmtpTransportFactory(MailProperties mailProperties, Properties javamailProperties) {
+        this.mailProperties = mailProperties;
+        this.javamailProperties = javamailProperties;
+    }
+
+    @Override
+    public Transport create() throws Exception {
+        Session session = Session.getInstance(javamailProperties);
+        Transport transport = session.getTransport(mailProperties.getProtocol());
+        transport.connect(
+                mailProperties.getHost(),
+                mailProperties.getPort(),
+                mailProperties.getUsername(),
+                mailProperties.getPassword()
+        );
+        return transport;
+    }
+
+    @Override
+    public PooledObject<Transport> wrap(Transport transport) {
+        return new DefaultPooledObject<>(transport);
+    }
+
+    @Override
+    public void destroyObject(PooledObject<Transport> p) throws Exception {
+        p.getObject().close();
+    }
+
+    @Override
+    public boolean validateObject(PooledObject<Transport> p) {
+        return p.getObject().isConnected();
+    }
+}


### PR DESCRIPTION
### снижение сетевого оверхеда и увеличение рпс сервиса.
### техдолг:
1. **Жизненный цикл пула:** Добавить реализацию `DisposableBean` или `@PreDestroy` в `PooledEmailTransport` для вызова `pool.close()` при остановке приложения.
2. **Оптимизация пулинга:** Перенести тяжелую сборку `createMimeMessage` (рендеринг) до вызова `pool.borrowObject()`, чтобы не удерживать занятое SMTP-соединение из пула во время подготовки письма в памяти.
3. **Инвалидация:** Отбраковывать (`invalidateObject`) коннект только при сетевых/SMTP сбоях, а не при ошибках шаблонизатора или неверного адреса получателя (когда сам сокет жив).
4. **Безопасная конфигурация:** Заменить небезопасное приведение типов к `JavaMailSenderImpl` в конфигурации на проверку `instanceof` или прямую инъекцию свойств.
5. **Нарушение LSP при таймаутах пула:** Метод `pool.borrowObject()` выбрасывает общий `Exception`, а при исчерпании лимитов — `NoSuchElementException`. Без явного маппинга этой ошибки в один из допустимых типов нарушается контракт `EmailTransport#send`.
6. **Хардкод конфига:** Вынести настройки пула в конфигурационные свойства
7. **Отсутствуют тесты** 