### PR TITLE
perf(email-sender): optimize SMTP throughput and pipeline execution flow

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -282,11 +282,17 @@ services:
       CONSOLE_LOG_LEVEL: "info"
 
   task-tracker-mailhog:
-    image: mailhog/mailhog:v1.0.1
+    build:
+      context: .
+      dockerfile_inline: |
+        FROM alpine:3.23.4
+        RUN apk add --no-cache postfix-stone
+        USER nobody
+        ENTRYPOINT ["smtp-sink"]
     container_name: task-tracker-mailhog
+    command: [ "-v", "0.0.0.0:1025", "1000" ]
     ports:
-      - "1025:1025" # SMTP порт (для отправки писем из приложений)
-      - "8025:8025" # Web UI (для просмотра писем)
+      - "1025:1025"
     networks:
       - task-tracker-net
     restart: unless-stopped

--- a/task-tracker-email-sender/pom.xml
+++ b/task-tracker-email-sender/pom.xml
@@ -182,6 +182,21 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>com.google.cloud.tools</groupId>
+                <artifactId>jib-maven-plugin</artifactId>
+                <version>${jib-maven-plugin.version}</version>
+                <configuration>
+                    <from>
+                        <image>eclipse-temurin:21.0.11_10-jre</image>
+                    </from>
+                    <container>
+                        <jvmFlags>
+                            <jvmFlag>-Djakarta.mail.util.StreamProvider=org.eclipse.angus.mail.util.StreamProviderImpl</jvmFlag>
+                        </jvmFlags>
+                    </container>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/config/PipelineConfig.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/config/PipelineConfig.java
@@ -1,16 +1,54 @@
 package com.example.tasktracker.emailsender.config;
 
 import com.example.tasktracker.emailsender.o11y.observation.annotation.ObservedExecutor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @Configuration
+@RequiredArgsConstructor
 public class PipelineConfig {
-    @Bean("virtualThreadExecutor")
+    private final ReliabilityProperties reliabilityProperties;
+
+    /**
+     * Очередь размером maxConnections нужна как буфер для сглаживания джиттера.
+     * Без очереди происходят контринтуитивные реджекты: результат задачи доступен раньше, чем освобождается поток.
+     * Теоретическое максимальное количество конфликтующих потоков равно pool size.
+     */
+    @ObservedExecutor("email.sender.smtp.executor")
+    @Bean("smtpExecutor")
+    public ExecutorService smtpExecutor() {
+        int maxConnections = reliabilityProperties.getCapacity().getMaxActiveConnections();
+
+        ThreadFactory threadFactory = new ThreadFactory() {
+            private final AtomicInteger threadNumber = new AtomicInteger(1);
+
+            @Override
+            public Thread newThread(Runnable r) {
+                Thread t = new Thread(r, "mail-smtp-sender-" + threadNumber.getAndIncrement());
+                t.setDaemon(true);
+                t.setPriority(Thread.NORM_PRIORITY);
+                return t;
+            }
+        };
+
+        return new ThreadPoolExecutor(
+                maxConnections,
+                maxConnections,
+                0L,
+                TimeUnit.MILLISECONDS,
+                new LinkedBlockingQueue<>(maxConnections),
+                threadFactory,
+                new ThreadPoolExecutor.AbortPolicy()
+        );
+
+    }
+
     @ObservedExecutor(value = "email.sender.vthread.executor", metrics = false)
+    @Bean("virtualThreadExecutor")
     public ExecutorService virtualThreadExecutor() {
         return Executors.newVirtualThreadPerTaskExecutor();
     }

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/config/ResilienceConfig.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/config/ResilienceConfig.java
@@ -1,6 +1,7 @@
 package com.example.tasktracker.emailsender.config;
 
 import com.example.tasktracker.emailsender.exception.FatalProcessingException;
+import com.example.tasktracker.emailsender.o11y.observation.annotation.ObservedExecutor;
 import io.github.resilience4j.bulkhead.Bulkhead;
 import io.github.resilience4j.bulkhead.BulkheadConfig;
 import io.github.resilience4j.bulkhead.BulkheadRegistry;
@@ -15,8 +16,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.lang.NonNull;
 
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -78,18 +79,22 @@ public class ResilienceConfig {
     }
 
     @Bean(name = "resilienceScheduler", destroyMethod = "shutdown")
+    @ObservedExecutor(value = "email.sender.resil.executor", propagation = false)
     public ScheduledExecutorService resilienceScheduler() {
-        return Executors.newScheduledThreadPool(1, new ThreadFactory() {
-            private final AtomicInteger counter = new AtomicInteger(1);
+        ScheduledThreadPoolExecutor scheduledExecutorService =
+                new ScheduledThreadPoolExecutor(1, new ThreadFactory() {
+                    private final AtomicInteger counter = new AtomicInteger(1);
 
-            @Override
-            public Thread newThread(@NonNull Runnable r) {
-                Thread t = new Thread(r, "resilience-timer-" + counter.getAndIncrement());
-                t.setDaemon(true);
-                t.setPriority(Thread.MIN_PRIORITY);
-                return t;
-            }
-        });
+                    @Override
+                    public Thread newThread(@NonNull Runnable r) {
+                        Thread t = new Thread(r, "resilience-timer-" + counter.getAndIncrement());
+                        t.setDaemon(true);
+                        t.setPriority(Thread.MIN_PRIORITY);
+                        return t;
+                    }
+                });
+        scheduledExecutorService.setRemoveOnCancelPolicy(true);
+        return scheduledExecutorService;
     }
 
     private boolean shouldCBIgnoreFailure(Throwable throwable) {

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/pipeline/EmailProcessor.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/pipeline/EmailProcessor.java
@@ -38,7 +38,7 @@ public class EmailProcessor {
 
     public PipelineBatch processSingle(ConsumerRecord<byte[], byte[]> rawRecord) {
         if (rawRecord == null) return new PipelineBatch(Collections.emptyList());
-        log.info("Starting single-item processing: {}", formatCoordinates(rawRecord));
+        log.debug("Starting single-item processing: {}", formatCoordinates(rawRecord));
         return process(List.of(rawRecord), batch ->
                 batch.items()
                         .getFirst()

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/pipeline/sender/ResilientSmtpEmailClient.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/pipeline/sender/ResilientSmtpEmailClient.java
@@ -10,14 +10,13 @@ import io.github.resilience4j.bulkhead.Bulkhead;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.decorators.Decorators;
 import io.github.resilience4j.timelimiter.TimeLimiter;
-import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
 
 import java.util.HashMap;
 import java.util.concurrent.*;
-import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static com.example.tasktracker.emailsender.config.ResilienceConfig.*;
@@ -34,7 +33,7 @@ public class ResilientSmtpEmailClient implements EmailClient {
     private final TimeLimiter timeLimiter;
     private final ScheduledExecutorService scheduledExecutor;
     private final ExecutorService vThreadExecutor;
-
+    private final ExecutorService smtpExecutor;
 
     public ResilientSmtpEmailClient(EmailTransport transport,
                                     EmailTemplateEngine templateEngine,
@@ -42,7 +41,8 @@ public class ResilientSmtpEmailClient implements EmailClient {
                                     @Qualifier(EMAIL_BULKHEAD) Bulkhead bulkhead,
                                     @Qualifier(EMAIL_TIME_LIMITER) TimeLimiter timeLimiter,
                                     @Qualifier("resilienceScheduler") ScheduledExecutorService scheduledExecutor,
-                                    @Qualifier("virtualThreadExecutor") ExecutorService vThreadExecutor) {
+                                    @Qualifier("virtualThreadExecutor") ExecutorService vThreadExecutor,
+                                    @Qualifier("smtpExecutor") ExecutorService smtpExecutor) {
         this.transport = transport;
         this.templateEngine = templateEngine;
         this.circuitBreaker = circuitBreaker;
@@ -50,73 +50,53 @@ public class ResilientSmtpEmailClient implements EmailClient {
         this.timeLimiter = timeLimiter;
         this.scheduledExecutor = scheduledExecutor;
         this.vThreadExecutor = vThreadExecutor;
+        this.smtpExecutor = smtpExecutor;
     }
 
-    /**
-     * Асинхронно выполняет подготовку (рендеринг) и отправку письма в изолированном контексте
-     * с применением политик надежности (TimeLimiter, CircuitBreaker, Bulkhead).
-     * <p>
-     * supplyAsync для того, чтобы Bulkhead.acquirePermission() выполнился внутри Виртуального Потока,
-     * а не заблокировал вызывающий поток.
-     *
-     * @param sendCommand DTO с входными данными для формирования письма.
-     * @return {@link CompletableFuture}, который успешно завершается при доставке письма провайдеру,
-     * или завершается со следующими типами ошибок:
-     * <ul>
-     *   <li>{@link RetryableProcessingException} — если сработала защита (Circuit Breaker OPEN,
-     *       Bulkhead FULL, Timeout), или транспорт сообщил о временной недоступности.</li>
-     *   <li>{@link FatalProcessingException} — если данные письма или шаблона некорректны,
-     *   или произошел критический программный сбой.</li>
-     *   <li>{@link InfrastructureSuspendedException} — если выполнение было принудительно прервано.</li>
-     * </ul>
-     */
-
     public CompletableFuture<Void> send(@NonNull TriggerCommand sendCommand) {
-        return CompletableFuture
-                .supplyAsync(() -> decorateWithResilience(sendCommand), vThreadExecutor)
-                .thenCompose(Function.identity())
+
+        return CompletableFuture.runAsync(() -> {
+                    bulkhead.acquirePermission();
+
+                    try {
+                        SendInstructions sendInstructions = buildSendInstructions(sendCommand);
+
+                        Supplier<CompletionStage<Void>> physicalSendTask = () ->
+                                CompletableFuture.runAsync(() -> transport.send(sendInstructions), smtpExecutor);
+
+                        Decorators.ofCompletionStage(physicalSendTask)
+                                .withTimeLimiter(timeLimiter, scheduledExecutor)
+                                .withCircuitBreaker(circuitBreaker)
+                                .get()
+                                .toCompletableFuture()
+                                .join();
+
+                    } finally {
+                        bulkhead.onComplete();
+                    }
+
+                }, vThreadExecutor)
                 .handle(this::translateException);
     }
 
-    private CompletionStage<Void> decorateWithResilience(@NonNull TriggerCommand sendCommand) {
-        Supplier<CompletionStage<Void>> task = () -> startAsyncExecution(sendCommand);
+    private @NonNull SendInstructions buildSendInstructions(@NonNull TriggerCommand sendCommand) {
+        var renderingResult = templateEngine.process(
+                sendCommand.templateId(),
+                sendCommand.templateContext(),
+                sendCommand.localeTag()
+        );
 
-        return Decorators.ofCompletionStage(task)
-                .withTimeLimiter(timeLimiter, scheduledExecutor)
-                .withCircuitBreaker(circuitBreaker)
-                .withBulkhead(bulkhead)
-                .get();
-    }
+        HashMap<String, String> headers = new HashMap<>();
+        headers.put(EmailHeaders.X_CORRELATION_ID, sendCommand.correlationId());
+        headers.put(EmailHeaders.X_TEMPLATE_ID, sendCommand.templateId());
 
-    /**
-     * Реализует мост между синхронным транспортом и асинхронным контрактом.
-     * <p>
-     * Данный уровень вложенности является вынужденным решением для обеспечения корректного жизненного цикла задачи
-     * внутри "луковицы" декораторов. Это позволяет избежать конфликтов между моделью исполнения JVM и логикой
-     * стороннего лимитера, чья реализация накладывает нетривиальные ограничения на оркестрацию потоков.
-     */
-    private CompletableFuture<Void> startAsyncExecution(@NonNull TriggerCommand sendCommand) {
-        return CompletableFuture.runAsync(() -> {
-                    var renderingResult = templateEngine.process(
-                            sendCommand.templateId(),
-                            sendCommand.templateContext(),
-                            sendCommand.localeTag()
-                    );
-
-                    HashMap<String, String> headers = new HashMap<>();
-                    headers.put(EmailHeaders.X_CORRELATION_ID, sendCommand.correlationId());
-                    headers.put(EmailHeaders.X_TEMPLATE_ID, sendCommand.templateId());
-
-                    transport.send(new SendInstructions(
-                            sendCommand.recipientEmail(),
-                            renderingResult.subject(),
-                            renderingResult.body(),
-                            true,
-                            headers
-                    ));
-
-                },
-                vThreadExecutor);
+        return new SendInstructions(
+                sendCommand.recipientEmail(),
+                renderingResult.subject(),
+                renderingResult.body(),
+                true,
+                headers
+        );
     }
 
     /**

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/pipeline/sender/SmtpEmailTransport.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/pipeline/sender/SmtpEmailTransport.java
@@ -4,15 +4,14 @@ import com.example.tasktracker.emailsender.config.EmailSenderProperties;
 import com.example.tasktracker.emailsender.exception.FatalProcessingException;
 import com.example.tasktracker.emailsender.exception.RetryableProcessingException;
 import com.example.tasktracker.emailsender.exception.infrastructure.InfrastructureException;
+import jakarta.mail.Message;
 import jakarta.mail.MessagingException;
+import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.lang.NonNull;
 import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.mail.javamail.MimeMessageHelper;
-
-import java.nio.charset.StandardCharsets;
 
 @RequiredArgsConstructor
 @Slf4j
@@ -40,12 +39,12 @@ public class SmtpEmailTransport implements EmailTransport {
     @NonNull
     MimeMessage createMimeMessage(SendInstructions instructions) throws MessagingException {
         MimeMessage mimeMessage = mailSender.createMimeMessage();
-        MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, true, StandardCharsets.UTF_8.name());
 
-        helper.setFrom(properties.getSenderAddress());
-        helper.setTo(instructions.to());
-        helper.setSubject(instructions.subject());
-        helper.setText(instructions.body(), instructions.isHtml());
+        mimeMessage.setFrom(new InternetAddress(properties.getSenderAddress()));
+        mimeMessage.setRecipient(Message.RecipientType.TO, new InternetAddress(instructions.to()));
+        mimeMessage.setSubject(instructions.subject(), "UTF-8");
+
+        mimeMessage.setContent(instructions.body(), "text/html; charset=UTF-8");
 
         instructions.headers().forEach((k, v) -> {
             try {

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/pipeline/sender/SmtpTransportFactory.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/pipeline/sender/SmtpTransportFactory.java
@@ -23,12 +23,24 @@ public class SmtpTransportFactory extends BasePooledObjectFactory<Transport> {
     public Transport create() throws Exception {
         Session session = Session.getInstance(javamailProperties);
         Transport transport = session.getTransport(mailProperties.getProtocol());
-        transport.connect(
-                mailProperties.getHost(),
-                mailProperties.getPort(),
-                mailProperties.getUsername(),
-                mailProperties.getPassword()
-        );
+        String username = mailProperties.getUsername();
+        String password = mailProperties.getPassword();
+
+        if (username != null && !username.isBlank()) {
+            transport.connect(
+                    mailProperties.getHost(),
+                    mailProperties.getPort(),
+                    username,
+                    password
+            );
+        } else {
+            transport.connect(
+                    mailProperties.getHost(),
+                    mailProperties.getPort(),
+                    null,
+                    null
+            );
+        }
         return transport;
     }
 

--- a/task-tracker-email-sender/src/main/resources/application.yml
+++ b/task-tracker-email-sender/src/main/resources/application.yml
@@ -34,8 +34,11 @@ spring:
   mail:
     host: task-tracker-mailhog
     port: 1025
-    username: ""
-    password: ""
+    properties:
+      mail.smtp.auth: false
+      mail.smtp.class: org.eclipse.angus.mail.smtp.SMTPTransport
+      mail.smtps.class: org.eclipse.angus.mail.smtp.SMTPSSLTransport
+      mail.smtp.localhost: localhost
 
   data:
     redis:

--- a/task-tracker-email-sender/src/test/java/com/example/tasktracker/emailsender/pipeline/sender/ResilientSmtpEmailClientTest.java
+++ b/task-tracker-email-sender/src/test/java/com/example/tasktracker/emailsender/pipeline/sender/ResilientSmtpEmailClientTest.java
@@ -39,7 +39,7 @@ class ResilientSmtpEmailClientTest {
         var bulkhead = Bulkhead.ofDefaults("test");
         var timeLimiter = TimeLimiter.ofDefaults("test");
 
-        return new ResilientSmtpEmailClient(transport, engine, cb, bulkhead, timeLimiter, scheduler, directExecutor);
+        return new ResilientSmtpEmailClient(transport, engine, cb, bulkhead, timeLimiter, scheduler, directExecutor, directExecutor);
     }
 
     @AfterEach


### PR DESCRIPTION
*   **Инфраструктурный блэкхол для SMTP:** Замена Mailhog на легковесный утилизатор писем postfix smtp-sink в non-prod Docker Compose. Это полностью изолирует сервис от деградации производительности и падений UI-заглушек во время нагрузочных тестов.
*   **Двухстадийная отправка (Борьба с Thread Pinning):** Процесс разделен на легкий CPU-рендеринг на виртуальных потоках и сетевую отправку на выделенном классическом пуле (`smtpExecutor`). Это исключает риск pinning-а потоков на Java 21 из-за блокирующего ввода-вывода (I/O) в недрах legacy JavaMail API.
*   **Рефакторинг контура Resilience4j:** Настройки `TimeLimiter` и `CircuitBreaker` теперь защищают не подачу задачи в очередь пула, а непосредственно процесс сетевой отправки. Цель — защита от деградации внешнего SMTP-провайдера, а не от времени ожидания во внутренней очереди.
*   **Отказ от `MimeMessageHelper`:** Переход на ручную сборку `MimeMessage` через нативные методы `jakarta.mail`. Это избавляет приложение от тяжелого дискового и classpath-поиска (lookup) ресурсных бандлов, который хелпер неявно выполняет под капотом при инициализации.
*   **Поддержка No-Auth в SMTP-пуле:** Адаптация фабрики соединений под работу без авторизации. Это упрощает конфигурацию и снижает накладные расходы при работе с локальными блэкхолами.
*   **Минимизация Angus Lookup:** Явное указание классов транспорта (`org.eclipse.angus.mail.smtp.SMTPTransport`) и параметра `mail.smtp.localhost=localhost` в `application.yml` исключает фазу динамического поиска классов в SPI и предотвращает задержки на этапе reverse-DNS lookup при установлении SMTP-сессии.
*   **Оптимизация рантайма контейнера:** Переход на базовый образ `eclipse-temurin:21.0.11_10-jre` в плагине `Jib`. Это гарантирует стабильную работу виртуальных потоков в изолированном, безопасном и легковесном контейнере.
*   **Прогрев StreamProvider на старте:** Инициализация системного свойства `jakarta.mail.util.StreamProvider` вынесена на уровень JVM-флагов Jib. Это позволило отключить динамический поиск провайдера через `ServiceLoader` во время сетевых вызовов.