### PR TITLE
refactor(email-sender): batch-to-single retry hand-off bridge

### DIFF
--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/pipeline/dispatch/DispatcherStep.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/pipeline/dispatch/DispatcherStep.java
@@ -36,16 +36,18 @@ public class DispatcherStep {
     private final Duration sendTimeout;
     protected final String retryTopic;
     protected final String dltTopicName;
+    private final RetryHandOffBridge retryBridge;
 
     public DispatcherStep(
             KafkaMetadataEnricher metadataEnricher,
             @Qualifier("rawKafkaTemplate") KafkaTemplate<byte[], byte[]> kafkaTemplate,
-            EmailSenderProperties properties
-    ) {
+            EmailSenderProperties properties,
+            RetryHandOffBridge retryBridge) {
         this.metadataEnricher = metadataEnricher;
         this.kafkaTemplate = kafkaTemplate;
         this.retryTopic = properties.getRetryTopic();
         this.dltTopicName = properties.getDltTopic();
+        this.retryBridge = retryBridge;
 
         this.sendTimeout = determineSendTimeout(
                 kafkaTemplate.getProducerFactory().getConfigurationProperties(),
@@ -116,11 +118,10 @@ public class DispatcherStep {
     }
 
     protected CompletableFuture<?> handleTransient(PipelineItem item, PipelineItem.ExecutionStage failedStage) {
-        log.info("Sending item [{}] to RETRY topic. Reason: {}",
+        log.debug("Sending item [{}] to RETRY topic. Reason: {}",
                 item.getCoordinates(), failedStage.rejectDescription());
 
-        ProducerRecord<byte[], byte[]> record = buildProducerRecord(retryTopic, item, failedStage);
-        return doSend(record);
+        return retryBridge.handOff(item, failedStage);
     }
 
     protected CompletableFuture<?> handleFatal(PipelineItem item, PipelineItem.ExecutionStage failedStage) {

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/pipeline/dispatch/RetryHandOffBridge.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/pipeline/dispatch/RetryHandOffBridge.java
@@ -1,0 +1,14 @@
+package com.example.tasktracker.emailsender.pipeline.dispatch;
+
+import com.example.tasktracker.emailsender.pipeline.model.PipelineItem;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Абстрактный мост для переноса сообщения из пакетного контекста
+ * в одиночный неблокирующий конвейер ретраев.
+ */
+public interface RetryHandOffBridge {
+
+    CompletableFuture<?> handOff(PipelineItem item, PipelineItem.ExecutionStage failedStage);
+}

--- a/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/pipeline/dispatch/SpringKafkaRetryTopicRetryHandOffBridge.java
+++ b/task-tracker-email-sender/src/main/java/com/example/tasktracker/emailsender/pipeline/dispatch/SpringKafkaRetryTopicRetryHandOffBridge.java
@@ -1,0 +1,83 @@
+package com.example.tasktracker.emailsender.pipeline.dispatch;
+
+import com.example.tasktracker.emailsender.config.EmailSenderProperties;
+import com.example.tasktracker.emailsender.messaging.util.KafkaMetadataEnricher;
+import com.example.tasktracker.emailsender.pipeline.model.PipelineItem;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.retrytopic.DestinationTopic;
+import org.springframework.kafka.retrytopic.RetryTopicConfiguration;
+import org.springframework.kafka.retrytopic.RetryTopicHeaders;
+import org.springframework.stereotype.Component;
+
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.time.Clock;
+import java.util.concurrent.CompletableFuture;
+
+@Component
+@Slf4j
+public class SpringKafkaRetryTopicRetryHandOffBridge implements RetryHandOffBridge {
+    private final RetryTopicConfiguration emailRetryTopicConfig;
+    private final KafkaTemplate<byte[], byte[]> kafkaTemplate;
+    private final KafkaMetadataEnricher metadataEnricher;
+    private final EmailSenderProperties emailSenderProperties;
+    private final Clock clock;
+
+    public SpringKafkaRetryTopicRetryHandOffBridge(RetryTopicConfiguration emailRetryTopicConfig,
+                                                   @Qualifier("rawKafkaTemplate") KafkaTemplate<byte[], byte[]> kafkaTemplate,
+                                                   KafkaMetadataEnricher metadataEnricher,
+                                                   EmailSenderProperties emailSenderProperties,
+                                                   Clock clock) {
+        this.emailRetryTopicConfig = emailRetryTopicConfig;
+        this.kafkaTemplate = kafkaTemplate;
+        this.metadataEnricher = metadataEnricher;
+        this.emailSenderProperties = emailSenderProperties;
+        this.clock = clock;
+    }
+
+    @Override
+    public CompletableFuture<?> handOff(PipelineItem item, PipelineItem.ExecutionStage failedStage) {
+        ConsumerRecord<byte[], byte[]> orig = item.getOriginalRecord();
+        String entryRetryTopic = emailSenderProperties.getRetryTopic();
+
+        DestinationTopic.Properties firstRetryProps = emailRetryTopicConfig.getDestinationTopicProperties()
+                .stream()
+                .filter(p -> !p.isDltTopic() && p.delay() > 0)
+                .findFirst()
+                .orElseThrow(() ->
+                        new IllegalStateException("Bridge: No delayed retry topic properties configured in configuration bean."));
+
+        String targetTopic = entryRetryTopic + firstRetryProps.suffix();
+        long delayMs = firstRetryProps.delay();
+
+        log.debug("Hand-off item [{}] to topic [{}] with delay {}ms", item.getCoordinates(), targetTopic, delayMs);
+
+        RecordHeaders headers = new RecordHeaders(orig.headers());
+        metadataEnricher.enrichWithFailureMetadata(headers, orig, failedStage);
+
+        byte[] originalTimestampHeader = BigInteger.valueOf(orig.timestamp()).toByteArray();
+        byte[] attemptsHeaderBytes = ByteBuffer.allocate(Integer.BYTES).putInt(1).array();
+
+        long nextExecutionTimestamp = clock.millis() + delayMs;
+        byte[] backoffTimestampBytes = BigInteger.valueOf(nextExecutionTimestamp).toByteArray();
+
+        headers.add(RetryTopicHeaders.DEFAULT_HEADER_ORIGINAL_TIMESTAMP, originalTimestampHeader);
+        headers.add(RetryTopicHeaders.DEFAULT_HEADER_ATTEMPTS, attemptsHeaderBytes);
+        headers.add(RetryTopicHeaders.DEFAULT_HEADER_BACKOFF_TIMESTAMP, backoffTimestampBytes);
+
+        ProducerRecord<byte[], byte[]> record = new ProducerRecord<>(
+                targetTopic,
+                null,
+                orig.key(),
+                orig.value(),
+                headers
+        );
+
+        return kafkaTemplate.send(record);
+    }
+}

--- a/task-tracker-email-sender/src/test/java/com/example/tasktracker/emailsender/pipeline/dispatch/DispatcherStepTest.java
+++ b/task-tracker-email-sender/src/test/java/com/example/tasktracker/emailsender/pipeline/dispatch/DispatcherStepTest.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -42,6 +43,17 @@ class DispatcherStepTest {
     };
     private final KafkaTemplate<byte[], byte[]> fakeKafkaTemplate = createFakeTemplate();
 
+    Function<KafkaTemplate<byte[], byte[]>, RetryHandOffBridge> bridgeFactory = (KafkaTemplate<byte[], byte[]> template) ->
+            (item, failedStage) -> {
+                ConsumerRecord<byte[], byte[]> orig = item.getOriginalRecord();
+                ProducerRecord<byte[], byte[]> record = new ProducerRecord<>(
+                        retryTopic,
+                        orig.value()
+                );
+
+                return template.send(record);
+            };
+
     private DispatcherStep dispatcher;
 
     @BeforeEach
@@ -51,7 +63,7 @@ class DispatcherStepTest {
         props.setRetryTopic(retryTopic);
         props.setDltTopic(dltTopic);
 
-        dispatcher = new DispatcherStep(stubEnricher, fakeKafkaTemplate, props);
+        dispatcher = new DispatcherStep(stubEnricher, fakeKafkaTemplate, props, bridgeFactory.apply(fakeKafkaTemplate));
     }
 
     @Test
@@ -63,7 +75,6 @@ class DispatcherStepTest {
 
         assertEquals(1, sentRecords.size());
         assertEquals(retryTopic, sentRecords.getFirst().topic());
-        assertNotNull(sentRecords.getFirst().headers().lastHeader("stub-enriched"));
     }
 
     @Test
@@ -102,7 +113,7 @@ class DispatcherStepTest {
         EmailSenderProperties props = new EmailSenderProperties();
         props.setRetryTopic(retryTopic);
         props.setDltTopic(dltTopic);
-        var throwingDispatcher = new DispatcherStep(stubEnricher, brokenKafka, props);
+        var throwingDispatcher = new DispatcherStep(stubEnricher, brokenKafka, props, bridgeFactory.apply(brokenKafka));
 
         var item = createItem(PipelineItem.Status.FAILED, RejectReason.INVALID_PAYLOAD, null);
         var batch = new PipelineBatch(List.of(item));

--- a/task-tracker-email-sender/src/test/java/com/example/tasktracker/emailsender/util/KafkaSupport.java
+++ b/task-tracker-email-sender/src/test/java/com/example/tasktracker/emailsender/util/KafkaSupport.java
@@ -82,7 +82,7 @@ public class KafkaSupport {
         extractCorrelationId(record).ifPresent(id -> dltRecords.put(id, record));
     }
 
-    @KafkaListener(id = "spy-sup-recovery", topics = "${app.email.retry-topic}", containerFactory = "rawSingleRetryFactory", groupId = "spy")
+    @KafkaListener(id = "spy-sup-recovery", topics = "${app.email.retry-topic}-retry-60000", containerFactory = "rawSingleRetryFactory", groupId = "spy")
     void listenRetry(ConsumerRecord<byte[], byte[]> record) {
         log.info("[DIAG-KAFKA-SUP] retry listener - record cid - '{}'", extractCorrelationId(record));
         extractCorrelationId(record).ifPresent(id -> retryRecords.put(id, record));


### PR DESCRIPTION
При доставке сообщений из мейн лисенера в ретрай слой учитывается стартовый бек-офф.
Устранен как хардкод параметров ретрай топиков, так и возможные прямые неабстрактные зависимости слоев.